### PR TITLE
Add netstandard build target for core assembly

### DIFF
--- a/Bonsai.Harp.Design/Bonsai.Harp.Design.csproj
+++ b/Bonsai.Harp.Design/Bonsai.Harp.Design.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Design" Version="2.5.0" />
+    <PackageReference Include="Bonsai.Design" Version="2.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bonsai.Harp.Design/DeviceConfigurationDialog.cs
+++ b/Bonsai.Harp.Design/DeviceConfigurationDialog.cs
@@ -1,5 +1,4 @@
 ﻿using Bonsai.Design;
-using Bonsai.Harp.Design.Properties;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -108,14 +107,14 @@ namespace Bonsai.Harp.Design
         private DialogResult ShouldResetDeviceName()
         {
             return MessageBox.Show(this,
-                Resources.ResetDeviceName_Question,
+                Properties.Resources.ResetDeviceName_Question,
                 Text, MessageBoxButtons.OKCancel);
         }
 
         private DialogResult ShouldResetPersistentRegisters()
         {
             return MessageBox.Show(this,
-                Resources.ResetPersistentRegisters_Question,
+                Properties.Resources.ResetPersistentRegisters_Question,
                 Text, MessageBoxButtons.OKCancel);
         }
 
@@ -202,7 +201,7 @@ namespace Bonsai.Harp.Design
         void UpdateFirmware(string path)
         {
             if (MessageBox.Show(this,
-                Resources.UpdateDeviceFirmware_Question, Text,
+                Properties.Resources.UpdateDeviceFirmware_Question, Text,
                 MessageBoxButtons.YesNo,
                 MessageBoxIcon.Warning,
                 MessageBoxDefaultButton.Button2) == DialogResult.Yes)
@@ -211,8 +210,8 @@ namespace Bonsai.Harp.Design
                 SetConnectionStatus(ConnectionStatus.Reset);
                 var deviceFirmware = DeviceFirmware.FromFile(path);
                 using (var firmwareDialog = new DeviceOperationDialog(
-                    Resources.UpdateDeviceFirmware_Label,
-                    Resources.UpdateDeviceFirmware_Caption,
+                    Properties.Resources.UpdateDeviceFirmware_Label,
+                    Properties.Resources.UpdateDeviceFirmware_Caption,
                     progress => Bootloader.UpdateFirmwareAsync(instance.PortName, deviceFirmware, progress)))
                 {
                     firmwareDialog.ShowDialog(this);
@@ -224,7 +223,7 @@ namespace Bonsai.Harp.Design
         bool UpdateDeviceName(string name)
         {
             if (MessageBox.Show(this,
-                Resources.UpdateDeviceName_Question, Text,
+                Properties.Resources.UpdateDeviceName_Question, Text,
                 MessageBoxButtons.YesNo,
                 MessageBoxIcon.Warning,
                 MessageBoxDefaultButton.Button2) == DialogResult.Yes)
@@ -232,8 +231,8 @@ namespace Bonsai.Harp.Design
                 CloseDevice();
                 SetConnectionStatus(ConnectionStatus.Reset);
                 using (var firmwareDialog = new DeviceOperationDialog(
-                    Resources.UpdateDeviceName_Label,
-                    Resources.UpdateDeviceName_Caption,
+                    Properties.Resources.UpdateDeviceName_Label,
+                    Properties.Resources.UpdateDeviceName_Caption,
                     progress => UpdateDeviceNameAsync(instance.PortName, name, progress)))
                 {
                     firmwareDialog.ShowDialog(this);

--- a/Bonsai.Harp.Design/DeviceConfigurationEditor.cs
+++ b/Bonsai.Harp.Design/DeviceConfigurationEditor.cs
@@ -1,5 +1,4 @@
 ﻿using Bonsai.Design;
-using Bonsai.Harp.Design.Properties;
 using System;
 using System.ComponentModel;
 using System.Reflection;
@@ -18,7 +17,7 @@ namespace Bonsai.Harp.Design
                 {
                     if (editorState.WorkflowRunning)
                     {
-                        throw new InvalidOperationException(Resources.WorkflowRunning_Error);
+                        throw new InvalidOperationException(Properties.Resources.WorkflowRunning_Error);
                     }
 
                     var device = (Device)component;

--- a/Bonsai.Harp.Tests/Bonsai.Harp.Tests.csproj
+++ b/Bonsai.Harp.Tests/Bonsai.Harp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <Version>3.4.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/Bonsai.Harp/Bonsai.Harp.csproj
+++ b/Bonsai.Harp/Bonsai.Harp.csproj
@@ -6,12 +6,16 @@
     <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>
     <PackageTags>Bonsai Rx Harp Hardware Protocol</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <VersionPrefix>3.4.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.5.0" />
+    <PackageReference Include="Bonsai.Core" Version="2.7.0-rc4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.IO.Ports" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bonsai.Harp/Bonsai.Harp.csproj
+++ b/Bonsai.Harp/Bonsai.Harp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.7.0-rc4" />
+    <PackageReference Include="Bonsai.Core" Version="2.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
This PR adds support for multi-targeting .NET standard against the latest `Bonsai.Core`.

Fixes #17 