### PR TITLE
Fix and extend support for creating Harp messages from payload data

### DIFF
--- a/Bonsai.Harp.Tests/TestHarpMessage.cs
+++ b/Bonsai.Harp.Tests/TestHarpMessage.cs
@@ -216,6 +216,17 @@ namespace Bonsai.Harp.Tests
         }
 
         [TestMethod]
+        public void FromPayload_Array_PayloadHasValue()
+        {
+            var payload = new byte[] { 0x92, 0x10 };
+            var value = BitConverter.ToUInt16(payload, 0);
+            var message = HarpCommand.Write(DefaultAddress, PayloadType.U16, payload);
+            AssertIsValid(message);
+            Assert.AreEqual(payload[1], message.GetPayloadByte(1));
+            Assert.AreEqual(value, message.GetPayloadUInt16());
+        }
+
+        [TestMethod]
         public void FromByte_TimestampedValue_PayloadHasValue()
         {
             byte value = 23;
@@ -438,6 +449,25 @@ namespace Bonsai.Harp.Tests
             AssertTimestamp(timestamp, actualTimestamp);
             AssertArrayEqual(value, payload);
             Assert.AreEqual(value[1], message.GetTimestampedPayloadSingle(1).Value);
+        }
+
+        [TestMethod]
+        public void FromPayload_TimestampedArray_PayloadHasValue()
+        {
+            var timestamp = GetTimestamp();
+            var payload = new byte[] { 0x92, 0x10 };
+            var value = BitConverter.ToUInt16(payload, 0);
+            var message = HarpMessage.FromPayload(
+                DefaultAddress,
+                timestamp,
+                MessageType.Write,
+                PayloadType.TimestampedU16,
+                payload);
+            AssertIsValid(message);
+            var actualTimestamp = message.GetTimestamp();
+            AssertTimestamp(timestamp, actualTimestamp);
+            AssertArrayEqual(payload, message.GetPayloadArray<byte>());
+            Assert.AreEqual(value, message.GetPayloadUInt16());
         }
     }
 }

--- a/Bonsai.Harp.Tests/TestHarpMessage.cs
+++ b/Bonsai.Harp.Tests/TestHarpMessage.cs
@@ -227,6 +227,18 @@ namespace Bonsai.Harp.Tests
         }
 
         [TestMethod]
+        public void FromPayload_ArraySegment_PayloadHasValue()
+        {
+            var payload = new byte[] { 0xFF, 0x92, 0x10, 0xFF };
+            var value = BitConverter.ToUInt16(payload, 1);
+            var payloadSegment = new ArraySegment<byte>(payload, 1, 2);
+            var message = HarpCommand.Write(DefaultAddress, PayloadType.U16, payloadSegment);
+            AssertIsValid(message);
+            Assert.AreEqual(payload[1], message.GetPayloadByte(0));
+            Assert.AreEqual(value, message.GetPayloadUInt16());
+        }
+
+        [TestMethod]
         public void FromByte_TimestampedValue_PayloadHasValue()
         {
             byte value = 23;
@@ -467,6 +479,26 @@ namespace Bonsai.Harp.Tests
             var actualTimestamp = message.GetTimestamp();
             AssertTimestamp(timestamp, actualTimestamp);
             AssertArrayEqual(payload, message.GetPayloadArray<byte>());
+            Assert.AreEqual(value, message.GetPayloadUInt16());
+        }
+
+        [TestMethod]
+        public void FromPayload_TimestampedArraySegment_PayloadHasValue()
+        {
+            var timestamp = GetTimestamp();
+            var payload = new byte[] { 0xFF, 0x92, 0x10, 0xFF };
+            var value = BitConverter.ToUInt16(payload, 1);
+            var payloadSegment = new ArraySegment<byte>(payload, 1, 2);
+            var message = HarpMessage.FromPayload(
+                DefaultAddress,
+                timestamp,
+                MessageType.Write,
+                PayloadType.TimestampedU16,
+                payloadSegment);
+            AssertIsValid(message);
+            var actualTimestamp = message.GetTimestamp();
+            AssertTimestamp(timestamp, actualTimestamp);
+            Assert.AreEqual(payloadSegment.Count, message.GetPayloadArray<byte>().Length);
             Assert.AreEqual(value, message.GetPayloadUInt16());
         }
     }

--- a/Bonsai.Harp/Format.cs
+++ b/Bonsai.Harp/Format.cs
@@ -1,4 +1,4 @@
-﻿using Bonsai.Expressions;
+using Bonsai.Expressions;
 using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
@@ -57,7 +57,9 @@ namespace Bonsai.Harp
             var messageType = Expression.Constant(MessageType);
             if (timestamped)
             {
-                var timestamp = Expression.PropertyOrField(expression, nameof(Timestamped<object>.Seconds));
+                Expression timestamp = Expression.PropertyOrField(expression, nameof(Timestamped<object>.Seconds));
+                if (timestamp.Type != typeof(double)) timestamp = Expression.Convert(timestamp, typeof(double));
+
                 expression = Expression.PropertyOrField(expression, nameof(Timestamped<object>.Value));
                 arguments = new[] { address, timestamp, messageType, expression };
             }

--- a/Bonsai.Harp/Format.cs
+++ b/Bonsai.Harp/Format.cs
@@ -1,4 +1,4 @@
-using Bonsai.Expressions;
+﻿using Bonsai.Expressions;
 using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
@@ -61,9 +61,22 @@ namespace Bonsai.Harp
                 if (timestamp.Type != typeof(double)) timestamp = Expression.Convert(timestamp, typeof(double));
 
                 expression = Expression.PropertyOrField(expression, nameof(Timestamped<object>.Value));
+                if (expression.Type == typeof(ArraySegment<byte>))
+                {
+                    arguments = new[] { address, timestamp, messageType, Expression.Constant(payloadType), expression };
+                    return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromPayload), null, arguments);
+                }
                 arguments = new[] { address, timestamp, messageType, expression };
             }
-            else arguments = new[] { address, messageType, expression };
+            else
+            {
+                if (expression.Type == typeof(ArraySegment<byte>))
+                {
+                    arguments = new[] { address, messageType, Expression.Constant(payloadType), expression };
+                    return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromPayload), null, arguments);
+                }
+                arguments = new[] { address, messageType, expression };
+            }
 
             switch (baseType)
             {

--- a/Bonsai.Harp/HarpCommand.cs
+++ b/Bonsai.Harp/HarpCommand.cs
@@ -213,6 +213,23 @@ namespace Bonsai.Harp
         }
 
         /// <summary>
+        /// Returns a <see cref="HarpMessage"/> write command with the specified address, and payload
+        /// data stored in the specified array segment.
+        /// </summary>
+        /// <param name="address">The address of the register to which the Harp message refers to.</param>
+        /// <param name="payloadType">The type of data available in the message payload.</param>
+        /// <param name="payload">
+        /// An array segment containing the raw binary representation of the payload data.
+        /// </param>
+        /// <returns>
+        /// A valid <see cref="HarpMessage"/> write command with the specified address and payload.
+        /// </returns>
+        public static HarpMessage Write(int address, PayloadType payloadType, ArraySegment<byte> payload)
+        {
+            return HarpMessage.FromPayload(address, MessageType.Write, payloadType, payload);
+        }
+
+        /// <summary>
         /// Returns a <see cref="HarpMessage"/> write command with the specified address, and a
         /// single value 8-bit unsigned integer payload.
         /// </summary>

--- a/Bonsai.Harp/HarpMessage.cs
+++ b/Bonsai.Harp/HarpMessage.cs
@@ -1175,7 +1175,7 @@ namespace Bonsai.Harp
         /// </returns>
         public static HarpMessage FromSByte(int address, int port, MessageType messageType, sbyte value)
         {
-            return FromBytes((byte)messageType, 0, (byte)address, (byte)port, (byte)PayloadType.U8, (byte)value, 0);
+            return FromBytes((byte)messageType, 0, (byte)address, (byte)port, (byte)PayloadType.S8, (byte)value, 0);
         }
 
         /// <summary>
@@ -1214,7 +1214,7 @@ namespace Bonsai.Harp
                 (byte)messageType, 0,
                 (byte)address,
                 (byte)port,
-                (byte)PayloadType.TimestampedU8,
+                (byte)PayloadType.TimestampedS8,
                 0, 0, 0, 0, 0, 0,
                 (byte)value,
                 0);
@@ -1248,7 +1248,7 @@ namespace Bonsai.Harp
         /// </returns>
         public static HarpMessage FromSByte(int address, int port, MessageType messageType, params sbyte[] values)
         {
-            return FromPayload(address, port, messageType, PayloadType.U8, values);
+            return FromPayload(address, port, messageType, PayloadType.S8, values);
         }
 
         /// <summary>
@@ -1282,7 +1282,7 @@ namespace Bonsai.Harp
         /// </returns>
         public static HarpMessage FromSByte(int address, int port, double timestamp, MessageType messageType, params sbyte[] values)
         {
-            return FromPayload(address, port, timestamp, messageType, PayloadType.TimestampedU8, values);
+            return FromPayload(address, port, timestamp, messageType, PayloadType.TimestampedS8, values);
         }
 
         /// <summary>

--- a/Bonsai.Harp/HarpMessage.cs
+++ b/Bonsai.Harp/HarpMessage.cs
@@ -922,6 +922,11 @@ namespace Bonsai.Harp
         static HarpMessage FromPayload(int address, int port, MessageType messageType, PayloadType payloadType, Array payload)
         {
             var payloadSize = payload.Length * (0xF & (byte)payloadType);
+            return FromPayload(address, port, messageType, payloadType, payload, payloadSize);
+        }
+
+        static HarpMessage FromPayload(int address, int port, MessageType messageType, PayloadType payloadType, Array payload, int payloadSize)
+        {
             var messageBytes = new byte[BaseOffset + payloadSize + ChecksumSize];
             messageBytes[0] = (byte)messageType;
             messageBytes[2] = (byte)address;
@@ -934,6 +939,11 @@ namespace Bonsai.Harp
         static HarpMessage FromPayload(int address, int port, double timestamp, MessageType messageType, PayloadType payloadType, Array payload)
         {
             var payloadSize = payload.Length * (0xF & (byte)payloadType);
+            return FromPayload(address, port, timestamp, messageType, payloadType, payload, payloadSize);
+        }
+
+        static HarpMessage FromPayload(int address, int port, double timestamp, MessageType messageType, PayloadType payloadType, Array payload, int payloadSize)
+        {
             var messageBytes = new byte[TimestampedOffset + payloadSize + ChecksumSize];
             messageBytes[0] = (byte)messageType;
             messageBytes[2] = (byte)address;
@@ -971,7 +981,7 @@ namespace Bonsai.Harp
         /// </returns>
         public static HarpMessage FromPayload(int address, int port, MessageType messageType, PayloadType payloadType, params byte[] payload)
         {
-            return FromPayload(address, port, messageType, payloadType, (Array)payload);
+            return FromPayload(address, port, messageType, payloadType, payload, payload.Length);
         }
 
         /// <summary>
@@ -1006,7 +1016,7 @@ namespace Bonsai.Harp
         /// </returns>
         public static HarpMessage FromPayload(int address, int port, double timestamp, MessageType messageType, PayloadType payloadType, params byte[] payload)
         {
-            return FromPayload(address, port, timestamp, messageType, payloadType, (Array)payload);
+            return FromPayload(address, port, timestamp, messageType, payloadType, payload, payload.Length);
         }
 
         /// <summary>

--- a/Bonsai.Harp/HarpMessage.cs
+++ b/Bonsai.Harp/HarpMessage.cs
@@ -985,6 +985,49 @@ namespace Bonsai.Harp
         }
 
         /// <summary>
+        /// Returns a <see cref="HarpMessage"/> with the specified address, message type, and payload
+        /// data stored in the specified array segment.
+        /// </summary>
+        /// <param name="address">The address of the register to which the Harp message refers to.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="payloadType">The type of data available in the message payload.</param>
+        /// <param name="payload">
+        /// An array segment containing the raw binary representation of the payload data.
+        /// </param>
+        /// <returns>
+        /// A valid <see cref="HarpMessage"/> instance with the specified address, message type, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(int address, MessageType messageType, PayloadType payloadType, ArraySegment<byte> payload)
+        {
+            return FromPayload(address, DevicePort, messageType, payloadType, payload);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="HarpMessage"/> with the specified address, message type, port, and payload
+        /// data stored in the specified array segment.
+        /// </summary>
+        /// <param name="address">The address of the register to which the Harp message refers to.</param>
+        /// <param name="port">The origin or destination of the Harp message, for routing purposes.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="payloadType">The type of data available in the message payload.</param>
+        /// <param name="payload">
+        /// An array segment containing the raw binary representation of the payload data.
+        /// </param>
+        /// <returns>
+        /// A valid <see cref="HarpMessage"/> instance with the specified address, message type, port, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(int address, int port, MessageType messageType, PayloadType payloadType, ArraySegment<byte> payload)
+        {
+            var messageBytes = new byte[BaseOffset + payload.Count + ChecksumSize];
+            messageBytes[0] = (byte)messageType;
+            messageBytes[2] = (byte)address;
+            messageBytes[3] = (byte)port;
+            messageBytes[4] = (byte)payloadType;
+            Buffer.BlockCopy(payload.Array, payload.Offset, messageBytes, BaseOffset, payload.Count);
+            return FromBytes(messageBytes);
+        }
+
+        /// <summary>
         /// Returns a <see cref="HarpMessage"/> with the specified address, message type, timestamp, and payload.
         /// </summary>
         /// <param name="address">The address of the register to which the Harp message refers to.</param>
@@ -1017,6 +1060,53 @@ namespace Bonsai.Harp
         public static HarpMessage FromPayload(int address, int port, double timestamp, MessageType messageType, PayloadType payloadType, params byte[] payload)
         {
             return FromPayload(address, port, timestamp, messageType, payloadType, payload, payload.Length);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="HarpMessage"/> with the specified address, message type,
+        /// timestamp, and payload data stored in the specified array segment.
+        /// </summary>
+        /// <param name="address">The address of the register to which the Harp message refers to.</param>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="payloadType">The type of data available in the message payload.</param>
+        /// <param name="payload">
+        /// An array segment containing the raw binary representation of the payload data.
+        /// </param>
+        /// <returns>
+        /// A valid <see cref="HarpMessage"/> instance with the specified address, message type,
+        /// timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(int address, double timestamp, MessageType messageType, PayloadType payloadType, ArraySegment<byte> payload)
+        {
+            return FromPayload(address, DevicePort, timestamp, messageType, payloadType, payload);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="HarpMessage"/> with the specified address, message type, port,
+        /// timestamp, and payload data stored in the specified array segment.
+        /// </summary>
+        /// <param name="address">The address of the register to which the Harp message refers to.</param>
+        /// <param name="port">The origin or destination of the Harp message, for routing purposes.</param>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="payloadType">The type of data available in the message payload.</param>
+        /// <param name="payload">
+        /// An array segment containing the raw binary representation of the payload data.
+        /// </param>
+        /// <returns>
+        /// A valid <see cref="HarpMessage"/> instance with the specified address, message type, port,
+        /// timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(int address, int port, double timestamp, MessageType messageType, PayloadType payloadType, ArraySegment<byte> payload)
+        {
+            var messageBytes = new byte[TimestampedOffset + payload.Count + ChecksumSize];
+            messageBytes[0] = (byte)messageType;
+            messageBytes[2] = (byte)address;
+            messageBytes[3] = (byte)port;
+            messageBytes[4] = (byte)payloadType;
+            Buffer.BlockCopy(payload.Array, payload.Offset, messageBytes, TimestampedOffset, payload.Count);
+            return FromBytes(timestamp, messageBytes);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes a number of issues relating to the creation of Harp messages from payload data. Regression tests are included for all functionality.

Fixes #13 
Fixes #14 
Fixes #15 
Fixes #16 