### PR TITLE
Mark CommandSubject as obsolete

### DIFF
--- a/Bonsai.Harp/CommandSubject.cs
+++ b/Bonsai.Harp/CommandSubject.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Bonsai.Harp
+{
+    [Obsolete]
+    internal class CommandSubject
+    {
+    }
+}


### PR DESCRIPTION
This PR leverages the new support for adding metadata ot embedded workflows to deprecate the now legacy `CommandSubject` operator.

Fixes #24 