### PR TITLE
Refactor timestamping operator logic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@
 indent_style = space
 
 # XML project files
-[*.{csproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+[*.{csproj,vcxproj,vcxproj.filters,proj,projitems,shproj,bonsai}]
 indent_size = 2
 
 # XML config files

--- a/Bonsai.Harp/MulticastTimestamp.cs
+++ b/Bonsai.Harp/MulticastTimestamp.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Bonsai.Harp
+{
+    [Obsolete]
+    internal class MulticastTimestamp
+    {
+    }
+}

--- a/Bonsai.Harp/TimestampSubject.cs
+++ b/Bonsai.Harp/TimestampSubject.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Bonsai.Harp
+{
+    [Obsolete]
+    internal class TimestampSubject
+    {
+    }
+}

--- a/Bonsai.Harp/WithLatestTimestamp.bonsai
+++ b/Bonsai.Harp/WithLatestTimestamp.bonsai
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.5.0"
+<WorkflowBuilder Version="2.7.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
-                 xmlns:scr="clr-namespace:Bonsai.Scripting;assembly=Bonsai.Scripting"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>Records the latest collected Harp timestamp for each element of the input sequence.</Description>
   <Workflow>
@@ -19,10 +19,8 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
-      <Expression xsi:type="scr:ExpressionTransform">
-        <scr:Expression>new(
-Item2 as Timestamp,
-Item1 as Value)</scr:Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:CreateTimestamped" />
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>


### PR DESCRIPTION
This PR introduces a refactoring of the Harp timestamping operators to take advantage of the new `CreateTimestamped` transform.

With this refactoring we avoid having to create new subjects separately, since timestamp sources can be declared simply using the existing reactive subjects. The `WithLatestTimestamp` operator has also been rewritten in a backwards compatible way so it can work with both the old and new timestamping logic.

Fixes #29 