### PR TITLE
Improve device configuration dialog and firmware bootloader

### DIFF
--- a/Bonsai.Harp.Design/DeviceConfiguration.cs
+++ b/Bonsai.Harp.Design/DeviceConfiguration.cs
@@ -9,21 +9,22 @@ namespace Bonsai.Harp.Design
         [Browsable(false)]
         public string Id
         {
-            get { return $"{WhoAmI}-{SerialNumber:x4}"; }
+            get { return !SerialNumber.HasValue ? $"{WhoAmI}" : $"{WhoAmI}-{SerialNumber:x4}"; }
             set
             {
                 var parts = value?.Split('-');
-                if (parts?.Length != 2)
+                if (parts?.Length <= 2)
                 {
-                    throw new ArgumentException("The id string is empty or has an invalid format.", nameof(value));
+                    throw new ArgumentException("The id string is null or has an invalid format.", nameof(value));
                 }
 
                 WhoAmI = int.Parse(parts[0]);
-                SerialNumber = int.Parse(parts[1], NumberStyles.HexNumber);
+                if (parts.Length == 2)
+                {
+                    SerialNumber = int.Parse(parts[1], NumberStyles.HexNumber);
+                }
             }
         }
-
-        internal int WhoAmI { get; set; }
 
         public string DeviceName { get; set; }
 
@@ -56,7 +57,9 @@ namespace Bonsai.Harp.Design
 
         public int AssemblyVersion { get; internal set; }
 
-        internal int? SerialNumber { get; set; }
+        public int WhoAmI { get; internal set; }
+
+        public int? SerialNumber { get; internal set; }
 
         [DisplayName("Timestamp (s)")]
         public uint Timestamp { get; internal set; }

--- a/Bonsai.Harp.Design/DeviceConfigurationDialog.Designer.cs
+++ b/Bonsai.Harp.Design/DeviceConfigurationDialog.Designer.cs
@@ -29,11 +29,14 @@ namespace Bonsai.Harp.Design
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DeviceConfigurationDialog));
             this.statusStrip = new System.Windows.Forms.StatusStrip();
             this.connectionStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.deviceInfoGroupBox = new System.Windows.Forms.GroupBox();
+            this.portNameComboBox = new System.Windows.Forms.ComboBox();
+            this.portNameBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.propertyGrid = new System.Windows.Forms.PropertyGrid();
             this.bootloaderButton = new System.Windows.Forms.Button();
             this.bootloaderGroupBox = new System.Windows.Forms.GroupBox();
@@ -47,6 +50,7 @@ namespace Bonsai.Harp.Design
             this.statusStrip.SuspendLayout();
             this.tableLayoutPanel.SuspendLayout();
             this.deviceInfoGroupBox.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.portNameBindingSource)).BeginInit();
             this.bootloaderGroupBox.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -55,44 +59,62 @@ namespace Bonsai.Harp.Design
             this.statusStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.connectionStatusLabel});
-            this.statusStrip.Location = new System.Drawing.Point(0, 227);
+            this.statusStrip.Location = new System.Drawing.Point(0, 273);
             this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(832, 26);
+            this.statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            this.statusStrip.Size = new System.Drawing.Size(932, 32);
             this.statusStrip.TabIndex = 0;
             this.statusStrip.Text = "statusStrip1";
             // 
             // connectionStatusLabel
             // 
             this.connectionStatusLabel.Name = "connectionStatusLabel";
-            this.connectionStatusLabel.Size = new System.Drawing.Size(50, 20);
+            this.connectionStatusLabel.Size = new System.Drawing.Size(60, 25);
             this.connectionStatusLabel.Text = "Ready";
             // 
             // tableLayoutPanel
             // 
             this.tableLayoutPanel.ColumnCount = 2;
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 37F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 63F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 38F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 62F));
             this.tableLayoutPanel.Controls.Add(this.deviceInfoGroupBox, 0, 0);
             this.tableLayoutPanel.Controls.Add(this.bootloaderGroupBox, 1, 0);
             this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.tableLayoutPanel.Name = "tableLayoutPanel";
             this.tableLayoutPanel.RowCount = 1;
             this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel.Size = new System.Drawing.Size(832, 227);
+            this.tableLayoutPanel.Size = new System.Drawing.Size(932, 273);
             this.tableLayoutPanel.TabIndex = 1;
             // 
             // deviceInfoGroupBox
             // 
+            this.deviceInfoGroupBox.Controls.Add(this.portNameComboBox);
             this.deviceInfoGroupBox.Controls.Add(this.propertyGrid);
             this.deviceInfoGroupBox.Controls.Add(this.bootloaderButton);
             this.deviceInfoGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.deviceInfoGroupBox.Location = new System.Drawing.Point(3, 3);
+            this.deviceInfoGroupBox.Location = new System.Drawing.Point(3, 4);
+            this.deviceInfoGroupBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.deviceInfoGroupBox.Name = "deviceInfoGroupBox";
-            this.deviceInfoGroupBox.Size = new System.Drawing.Size(301, 221);
+            this.deviceInfoGroupBox.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.deviceInfoGroupBox.Size = new System.Drawing.Size(348, 265);
             this.deviceInfoGroupBox.TabIndex = 0;
             this.deviceInfoGroupBox.TabStop = false;
             this.deviceInfoGroupBox.Text = "Device Info";
+            // 
+            // portNameComboBox
+            // 
+            this.portNameComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.portNameComboBox.DataSource = this.portNameBindingSource;
+            this.portNameComboBox.FormattingEnabled = true;
+            this.portNameComboBox.Location = new System.Drawing.Point(10, 223);
+            this.portNameComboBox.Name = "portNameComboBox";
+            this.portNameComboBox.Size = new System.Drawing.Size(94, 28);
+            this.portNameComboBox.TabIndex = 2;
+            this.portNameComboBox.DropDown += new System.EventHandler(this.portNameComboBox_DropDown);
+            this.portNameComboBox.SelectionChangeCommitted += new System.EventHandler(this.portNameComboBox_SelectionChangeCommitted);
+            this.portNameComboBox.Validated += new System.EventHandler(this.portNameComboBox_Validated);
             // 
             // propertyGrid
             // 
@@ -101,10 +123,11 @@ namespace Bonsai.Harp.Design
             | System.Windows.Forms.AnchorStyles.Right)));
             this.propertyGrid.CommandsVisibleIfAvailable = false;
             this.propertyGrid.HelpVisible = false;
-            this.propertyGrid.Location = new System.Drawing.Point(9, 21);
+            this.propertyGrid.Location = new System.Drawing.Point(10, 26);
+            this.propertyGrid.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.propertyGrid.Name = "propertyGrid";
             this.propertyGrid.PropertySort = System.Windows.Forms.PropertySort.NoSort;
-            this.propertyGrid.Size = new System.Drawing.Size(286, 154);
+            this.propertyGrid.Size = new System.Drawing.Size(331, 181);
             this.propertyGrid.TabIndex = 1;
             this.propertyGrid.ToolbarVisible = false;
             this.propertyGrid.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propertyGrid_PropertyValueChanged);
@@ -112,9 +135,10 @@ namespace Bonsai.Harp.Design
             // bootloaderButton
             // 
             this.bootloaderButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.bootloaderButton.Location = new System.Drawing.Point(182, 181);
+            this.bootloaderButton.Location = new System.Drawing.Point(214, 215);
+            this.bootloaderButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.bootloaderButton.Name = "bootloaderButton";
-            this.bootloaderButton.Size = new System.Drawing.Size(113, 34);
+            this.bootloaderButton.Size = new System.Drawing.Size(127, 42);
             this.bootloaderButton.TabIndex = 0;
             this.bootloaderButton.Text = "Bootloader >>";
             this.bootloaderButton.UseVisualStyleBackColor = true;
@@ -129,9 +153,11 @@ namespace Bonsai.Harp.Design
             this.bootloaderGroupBox.Controls.Add(this.selectFirmwareButton);
             this.bootloaderGroupBox.Controls.Add(this.updateFirmwareButton);
             this.bootloaderGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bootloaderGroupBox.Location = new System.Drawing.Point(310, 3);
+            this.bootloaderGroupBox.Location = new System.Drawing.Point(357, 4);
+            this.bootloaderGroupBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.bootloaderGroupBox.Name = "bootloaderGroupBox";
-            this.bootloaderGroupBox.Size = new System.Drawing.Size(519, 221);
+            this.bootloaderGroupBox.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.bootloaderGroupBox.Size = new System.Drawing.Size(572, 265);
             this.bootloaderGroupBox.TabIndex = 1;
             this.bootloaderGroupBox.TabStop = false;
             this.bootloaderGroupBox.Text = "Update Firmware";
@@ -139,9 +165,10 @@ namespace Bonsai.Harp.Design
             // resetNameButton
             // 
             this.resetNameButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.resetNameButton.Location = new System.Drawing.Point(365, 21);
+            this.resetNameButton.Location = new System.Drawing.Point(399, 26);
+            this.resetNameButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.resetNameButton.Name = "resetNameButton";
-            this.resetNameButton.Size = new System.Drawing.Size(145, 48);
+            this.resetNameButton.Size = new System.Drawing.Size(163, 60);
             this.resetNameButton.TabIndex = 6;
             this.resetNameButton.Text = "Reset Device Name...";
             this.resetNameButton.UseVisualStyleBackColor = true;
@@ -149,9 +176,10 @@ namespace Bonsai.Harp.Design
             // resetSettingsButton
             // 
             this.resetSettingsButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.resetSettingsButton.Location = new System.Drawing.Point(365, 75);
+            this.resetSettingsButton.Location = new System.Drawing.Point(399, 94);
+            this.resetSettingsButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.resetSettingsButton.Name = "resetSettingsButton";
-            this.resetSettingsButton.Size = new System.Drawing.Size(145, 48);
+            this.resetSettingsButton.Size = new System.Drawing.Size(163, 60);
             this.resetSettingsButton.TabIndex = 5;
             this.resetSettingsButton.Text = "Reset Device Settings...";
             this.resetSettingsButton.UseVisualStyleBackColor = true;
@@ -163,10 +191,11 @@ namespace Bonsai.Harp.Design
             | System.Windows.Forms.AnchorStyles.Right)));
             this.firmwarePropertyGrid.CommandsVisibleIfAvailable = false;
             this.firmwarePropertyGrid.HelpVisible = false;
-            this.firmwarePropertyGrid.Location = new System.Drawing.Point(6, 21);
+            this.firmwarePropertyGrid.Location = new System.Drawing.Point(7, 26);
+            this.firmwarePropertyGrid.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.firmwarePropertyGrid.Name = "firmwarePropertyGrid";
             this.firmwarePropertyGrid.PropertySort = System.Windows.Forms.PropertySort.NoSort;
-            this.firmwarePropertyGrid.Size = new System.Drawing.Size(353, 154);
+            this.firmwarePropertyGrid.Size = new System.Drawing.Size(385, 181);
             this.firmwarePropertyGrid.TabIndex = 4;
             this.firmwarePropertyGrid.ToolbarVisible = false;
             // 
@@ -174,10 +203,11 @@ namespace Bonsai.Harp.Design
             // 
             this.warningTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.warningTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.warningTextBox.Location = new System.Drawing.Point(6, 181);
+            this.warningTextBox.Location = new System.Drawing.Point(7, 215);
+            this.warningTextBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.warningTextBox.Name = "warningTextBox";
             this.warningTextBox.ReadOnly = true;
-            this.warningTextBox.Size = new System.Drawing.Size(353, 34);
+            this.warningTextBox.Size = new System.Drawing.Size(385, 42);
             this.warningTextBox.TabIndex = 3;
             this.warningTextBox.Text = "Caution: Selecting a firmware that was not designed for this Harp device may caus" +
     "e permanent damage.";
@@ -185,9 +215,10 @@ namespace Bonsai.Harp.Design
             // selectFirmwareButton
             // 
             this.selectFirmwareButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.selectFirmwareButton.Location = new System.Drawing.Point(362, 181);
+            this.selectFirmwareButton.Location = new System.Drawing.Point(395, 215);
+            this.selectFirmwareButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.selectFirmwareButton.Name = "selectFirmwareButton";
-            this.selectFirmwareButton.Size = new System.Drawing.Size(71, 34);
+            this.selectFirmwareButton.Size = new System.Drawing.Size(80, 42);
             this.selectFirmwareButton.TabIndex = 2;
             this.selectFirmwareButton.Text = "Open...";
             this.selectFirmwareButton.UseVisualStyleBackColor = true;
@@ -197,9 +228,10 @@ namespace Bonsai.Harp.Design
             // 
             this.updateFirmwareButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.updateFirmwareButton.Enabled = false;
-            this.updateFirmwareButton.Location = new System.Drawing.Point(439, 181);
+            this.updateFirmwareButton.Location = new System.Drawing.Point(482, 215);
+            this.updateFirmwareButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.updateFirmwareButton.Name = "updateFirmwareButton";
-            this.updateFirmwareButton.Size = new System.Drawing.Size(71, 34);
+            this.updateFirmwareButton.Size = new System.Drawing.Size(80, 42);
             this.updateFirmwareButton.TabIndex = 1;
             this.updateFirmwareButton.Text = "Update";
             this.updateFirmwareButton.UseVisualStyleBackColor = true;
@@ -211,21 +243,23 @@ namespace Bonsai.Harp.Design
             // 
             // DeviceConfigurationDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(832, 253);
+            this.ClientSize = new System.Drawing.Size(932, 305);
             this.Controls.Add(this.tableLayoutPanel);
             this.Controls.Add(this.statusStrip);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(850, 300);
-            this.MinimumSize = new System.Drawing.Size(850, 300);
+            this.MaximumSize = new System.Drawing.Size(954, 361);
+            this.MinimumSize = new System.Drawing.Size(954, 361);
             this.Name = "DeviceConfigurationDialog";
             this.Text = "Device Setup";
             this.statusStrip.ResumeLayout(false);
             this.statusStrip.PerformLayout();
             this.tableLayoutPanel.ResumeLayout(false);
             this.deviceInfoGroupBox.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.portNameBindingSource)).EndInit();
             this.bootloaderGroupBox.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -248,5 +282,7 @@ namespace Bonsai.Harp.Design
         private System.Windows.Forms.PropertyGrid firmwarePropertyGrid;
         private System.Windows.Forms.Button resetNameButton;
         private System.Windows.Forms.Button resetSettingsButton;
+        private System.Windows.Forms.ComboBox portNameComboBox;
+        private System.Windows.Forms.BindingSource portNameBindingSource;
     }
 }

--- a/Bonsai.Harp.Design/DeviceConfigurationDialog.Designer.cs
+++ b/Bonsai.Harp.Design/DeviceConfigurationDialog.Designer.cs
@@ -59,7 +59,7 @@ namespace Bonsai.Harp.Design
             this.statusStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.connectionStatusLabel});
-            this.statusStrip.Location = new System.Drawing.Point(0, 273);
+            this.statusStrip.Location = new System.Drawing.Point(0, 282);
             this.statusStrip.Name = "statusStrip";
             this.statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
             this.statusStrip.Size = new System.Drawing.Size(932, 32);
@@ -85,7 +85,7 @@ namespace Bonsai.Harp.Design
             this.tableLayoutPanel.Name = "tableLayoutPanel";
             this.tableLayoutPanel.RowCount = 1;
             this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel.Size = new System.Drawing.Size(932, 273);
+            this.tableLayoutPanel.Size = new System.Drawing.Size(932, 282);
             this.tableLayoutPanel.TabIndex = 1;
             // 
             // deviceInfoGroupBox
@@ -98,7 +98,7 @@ namespace Bonsai.Harp.Design
             this.deviceInfoGroupBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.deviceInfoGroupBox.Name = "deviceInfoGroupBox";
             this.deviceInfoGroupBox.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.deviceInfoGroupBox.Size = new System.Drawing.Size(348, 265);
+            this.deviceInfoGroupBox.Size = new System.Drawing.Size(348, 274);
             this.deviceInfoGroupBox.TabIndex = 0;
             this.deviceInfoGroupBox.TabStop = false;
             this.deviceInfoGroupBox.Text = "Device Info";
@@ -108,7 +108,7 @@ namespace Bonsai.Harp.Design
             this.portNameComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.portNameComboBox.DataSource = this.portNameBindingSource;
             this.portNameComboBox.FormattingEnabled = true;
-            this.portNameComboBox.Location = new System.Drawing.Point(10, 223);
+            this.portNameComboBox.Location = new System.Drawing.Point(10, 232);
             this.portNameComboBox.Name = "portNameComboBox";
             this.portNameComboBox.Size = new System.Drawing.Size(94, 28);
             this.portNameComboBox.TabIndex = 2;
@@ -127,7 +127,7 @@ namespace Bonsai.Harp.Design
             this.propertyGrid.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.propertyGrid.Name = "propertyGrid";
             this.propertyGrid.PropertySort = System.Windows.Forms.PropertySort.NoSort;
-            this.propertyGrid.Size = new System.Drawing.Size(331, 181);
+            this.propertyGrid.Size = new System.Drawing.Size(331, 190);
             this.propertyGrid.TabIndex = 1;
             this.propertyGrid.ToolbarVisible = false;
             this.propertyGrid.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propertyGrid_PropertyValueChanged);
@@ -135,7 +135,7 @@ namespace Bonsai.Harp.Design
             // bootloaderButton
             // 
             this.bootloaderButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.bootloaderButton.Location = new System.Drawing.Point(214, 215);
+            this.bootloaderButton.Location = new System.Drawing.Point(214, 224);
             this.bootloaderButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.bootloaderButton.Name = "bootloaderButton";
             this.bootloaderButton.Size = new System.Drawing.Size(127, 42);
@@ -157,7 +157,7 @@ namespace Bonsai.Harp.Design
             this.bootloaderGroupBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.bootloaderGroupBox.Name = "bootloaderGroupBox";
             this.bootloaderGroupBox.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.bootloaderGroupBox.Size = new System.Drawing.Size(572, 265);
+            this.bootloaderGroupBox.Size = new System.Drawing.Size(572, 274);
             this.bootloaderGroupBox.TabIndex = 1;
             this.bootloaderGroupBox.TabStop = false;
             this.bootloaderGroupBox.Text = "Update Firmware";
@@ -195,7 +195,7 @@ namespace Bonsai.Harp.Design
             this.firmwarePropertyGrid.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.firmwarePropertyGrid.Name = "firmwarePropertyGrid";
             this.firmwarePropertyGrid.PropertySort = System.Windows.Forms.PropertySort.NoSort;
-            this.firmwarePropertyGrid.Size = new System.Drawing.Size(385, 181);
+            this.firmwarePropertyGrid.Size = new System.Drawing.Size(385, 190);
             this.firmwarePropertyGrid.TabIndex = 4;
             this.firmwarePropertyGrid.ToolbarVisible = false;
             // 
@@ -203,7 +203,7 @@ namespace Bonsai.Harp.Design
             // 
             this.warningTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.warningTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.warningTextBox.Location = new System.Drawing.Point(7, 215);
+            this.warningTextBox.Location = new System.Drawing.Point(7, 224);
             this.warningTextBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.warningTextBox.Name = "warningTextBox";
             this.warningTextBox.ReadOnly = true;
@@ -215,7 +215,7 @@ namespace Bonsai.Harp.Design
             // selectFirmwareButton
             // 
             this.selectFirmwareButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.selectFirmwareButton.Location = new System.Drawing.Point(395, 215);
+            this.selectFirmwareButton.Location = new System.Drawing.Point(395, 224);
             this.selectFirmwareButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.selectFirmwareButton.Name = "selectFirmwareButton";
             this.selectFirmwareButton.Size = new System.Drawing.Size(80, 42);
@@ -228,7 +228,7 @@ namespace Bonsai.Harp.Design
             // 
             this.updateFirmwareButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.updateFirmwareButton.Enabled = false;
-            this.updateFirmwareButton.Location = new System.Drawing.Point(482, 215);
+            this.updateFirmwareButton.Location = new System.Drawing.Point(482, 224);
             this.updateFirmwareButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.updateFirmwareButton.Name = "updateFirmwareButton";
             this.updateFirmwareButton.Size = new System.Drawing.Size(80, 42);
@@ -245,14 +245,14 @@ namespace Bonsai.Harp.Design
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(932, 305);
+            this.ClientSize = new System.Drawing.Size(932, 314);
             this.Controls.Add(this.tableLayoutPanel);
             this.Controls.Add(this.statusStrip);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(954, 361);
-            this.MinimumSize = new System.Drawing.Size(954, 361);
+            this.MaximumSize = new System.Drawing.Size(954, 370);
+            this.MinimumSize = new System.Drawing.Size(954, 370);
             this.Name = "DeviceConfigurationDialog";
             this.Text = "Device Setup";
             this.statusStrip.ResumeLayout(false);

--- a/Bonsai.Harp.Design/DeviceConfigurationDialog.cs
+++ b/Bonsai.Harp.Design/DeviceConfigurationDialog.cs
@@ -190,7 +190,7 @@ namespace Bonsai.Harp.Design
                     connectionStatusLabel.Text = "Connecting to device...";
                     break;
                 case ConnectionStatus.Ready:
-                    connectionStatusLabel.Text = $"Ready ({instance.PortName}: {configuration.Id})";
+                    connectionStatusLabel.Text = $"Ready ({instance.PortName})";
                     break;
                 case ConnectionStatus.Reset:
                     connectionStatusLabel.Text = "Resetting device...";
@@ -200,7 +200,6 @@ namespace Bonsai.Harp.Design
                     break;
                 default:
                     break;
-         
             }
         }
 

--- a/Bonsai.Harp.Design/DeviceConfigurationDialog.cs
+++ b/Bonsai.Harp.Design/DeviceConfigurationDialog.cs
@@ -1,4 +1,4 @@
-﻿using Bonsai.Design;
+using Bonsai.Design;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -200,19 +200,34 @@ namespace Bonsai.Harp.Design
 
         void UpdateFirmware(string path)
         {
-            if (MessageBox.Show(this,
-                Properties.Resources.UpdateDeviceFirmware_Question, Text,
+            var deviceFirmware = DeviceFirmware.FromFile(path);
+            var forceUpdate = ModifierKeys == (Keys.Shift | Keys.Control | Keys.Alt);
+            if (!deviceFirmware.Metadata.Supports(configuration.DeviceName, configuration.HardwareVersion) &&
+                !forceUpdate)
+            {
+                MessageBox.Show(this,
+                    Properties.Resources.UpdateDeviceFirmware_NotSupported,
+                    Properties.Resources.UpdateDeviceFirmware_Caption,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            else if (MessageBox.Show(this,
+                Properties.Resources.UpdateDeviceFirmware_Question,
+                Properties.Resources.UpdateDeviceFirmware_Caption,
                 MessageBoxButtons.YesNo,
                 MessageBoxIcon.Warning,
                 MessageBoxDefaultButton.Button2) == DialogResult.Yes)
             {
                 CloseDevice();
                 SetConnectionStatus(ConnectionStatus.Reset);
-                var deviceFirmware = DeviceFirmware.FromFile(path);
                 using (var firmwareDialog = new DeviceOperationDialog(
                     Properties.Resources.UpdateDeviceFirmware_Label,
                     Properties.Resources.UpdateDeviceFirmware_Caption,
-                    progress => Bootloader.UpdateFirmwareAsync(instance.PortName, deviceFirmware, progress)))
+                    progress => Bootloader.UpdateFirmwareAsync(
+                        instance.PortName,
+                        deviceFirmware,
+                        forceUpdate,
+                        progress)))
                 {
                     firmwareDialog.ShowDialog(this);
                 }

--- a/Bonsai.Harp.Design/DeviceConfigurationDialog.resx
+++ b/Bonsai.Harp.Design/DeviceConfigurationDialog.resx
@@ -120,6 +120,9 @@
   <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="portNameBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>329, 17</value>
+  </metadata>
   <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>145, 17</value>
   </metadata>

--- a/Bonsai.Harp.Design/Properties/Resources.Designer.cs
+++ b/Bonsai.Harp.Design/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Bonsai.Harp.Design.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -103,6 +103,15 @@ namespace Bonsai.Harp.Design.Properties {
         internal static string UpdateDeviceFirmware_Label {
             get {
                 return ResourceManager.GetString("UpdateDeviceFirmware_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The specified firmware is not supported by the device hardware..
+        /// </summary>
+        internal static string UpdateDeviceFirmware_NotSupported {
+            get {
+                return ResourceManager.GetString("UpdateDeviceFirmware_NotSupported", resourceCulture);
             }
         }
         

--- a/Bonsai.Harp.Design/Properties/Resources.resx
+++ b/Bonsai.Harp.Design/Properties/Resources.resx
@@ -133,6 +133,9 @@
   <data name="UpdateDeviceFirmware_Label" xml:space="preserve">
     <value>Updating device firmware. Please wait...</value>
   </data>
+  <data name="UpdateDeviceFirmware_NotSupported" xml:space="preserve">
+    <value>The specified firmware is not supported by the device hardware.</value>
+  </data>
   <data name="UpdateDeviceFirmware_Question" xml:space="preserve">
     <value>Are you sure you want to update the device firmware? This action cannot be undone.</value>
   </data>

--- a/Bonsai.Harp/FirmwareMetadata.cs
+++ b/Bonsai.Harp/FirmwareMetadata.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -21,63 +20,53 @@ namespace Bonsai.Harp
         /// <param name="firmwareVersion">The version of the firmware contained in the device or hex file.</param>
         /// <param name="coreVersion">The version of the Harp core implemented by the firmware.</param>
         /// <param name="hardwareVersion">The hardware version of the device, or range of hardware versions supported by the firmware.</param>
-        /// <param name="assemblyNumber">The board assembly version of the device, or range of assembly versions supported by the firmware.</param>
+        /// <param name="assemblyVersion">The board assembly version of the device, or range of assembly versions supported by the firmware.</param>
         /// <param name="prereleaseVersion">The optional prerelease number, for preview versions of the firmware.</param>
         public FirmwareMetadata(
             string deviceName,
             HarpVersion firmwareVersion,
             HarpVersion coreVersion,
             HarpVersion hardwareVersion,
-            int? assemblyNumber = default,
+            int? assemblyVersion = default,
             int? prereleaseVersion = default)
         {
             DeviceName = deviceName ?? throw new ArgumentNullException(nameof(deviceName));
             FirmwareVersion = firmwareVersion ?? throw new ArgumentNullException(nameof(firmwareVersion));
             CoreVersion = coreVersion ?? throw new ArgumentNullException(nameof(coreVersion));
             HardwareVersion = hardwareVersion ?? throw new ArgumentNullException(nameof(hardwareVersion));
-            AssemblyNumber = assemblyNumber;
+            AssemblyVersion = assemblyVersion;
             PrereleaseVersion = prereleaseVersion;
         }
 
         /// <summary>
         /// Gets the unique identifier of the device type on which the firmware should be installed.
         /// </summary>
-        public string DeviceName { get; private set; }
+        public string DeviceName { get; }
 
         /// <summary>
         /// Gets the version of the firmware contained in the device or hex file.
         /// </summary>
-        public HarpVersion FirmwareVersion { get; private set; }
+        public HarpVersion FirmwareVersion { get; }
 
         /// <summary>
         /// Gets the version of the Harp core implemented by the firmware.
         /// </summary>
-        public HarpVersion CoreVersion { get; private set; }
+        public HarpVersion CoreVersion { get; }
 
         /// <summary>
         /// Gets the hardware version of the device, or range of hardware versions supported by the firmware.
         /// </summary>
-        public HarpVersion HardwareVersion { get; private set; }
+        public HarpVersion HardwareVersion { get; }
 
         /// <summary>
         /// Gets the board assembly version of the device, or range of assembly versions supported by the firmware.
         /// </summary>
-        public int? AssemblyNumber { get; private set; }
+        public int? AssemblyVersion { get; }
 
         /// <summary>
         /// Gets the optional prerelease number, for preview versions of the firmware.
         /// </summary>
-        public int? PrereleaseVersion { get; private set; }
-
-        [Obsolete]
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public HarpVersion ProtocolVersion
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-        {
-            get { return CoreVersion; }
-        }
+        public int? PrereleaseVersion { get; }
 
         /// <summary>
         /// Returns whether the firmware supports the specified hardware version
@@ -85,16 +74,16 @@ namespace Bonsai.Harp
         /// </summary>
         /// <param name="deviceName">The identifier of the device to check for compatibility.</param>
         /// <param name="hardwareVersion">The hardware version to check for compatibility.</param>
-        /// <param name="assemblyNumber">The optional board assembly number to check for compatibility.</param>
+        /// <param name="assemblyVersion">The optional board assembly version to check for compatibility.</param>
         /// <returns>
         /// <b>true</b> if the firmware supports the specified <paramref name="hardwareVersion"/> and
-        /// <paramref name="assemblyNumber"/>; otherwise, <b>false</b>.
+        /// <paramref name="assemblyVersion"/>; otherwise, <b>false</b>.
         /// </returns>
-        public bool Supports(string deviceName, HarpVersion hardwareVersion, int assemblyNumber = default)
+        public bool Supports(string deviceName, HarpVersion hardwareVersion, int assemblyVersion = default)
         {
             return DeviceName == deviceName &&
                    HardwareVersion.Satisfies(hardwareVersion) &&
-                   (!AssemblyNumber.HasValue || AssemblyNumber.Value == assemblyNumber);
+                   (!AssemblyVersion.HasValue || AssemblyVersion.Value == assemblyVersion);
         }
 
         /// <summary>
@@ -126,7 +115,7 @@ namespace Bonsai.Harp
                    FirmwareVersion.Equals(other.FirmwareVersion) &&
                    CoreVersion.Equals(other.CoreVersion) &&
                    HardwareVersion.Equals(other.HardwareVersion) &&
-                   AssemblyNumber == other.AssemblyNumber &&
+                   AssemblyVersion == other.AssemblyVersion &&
                    PrereleaseVersion == other.PrereleaseVersion;
         }
 
@@ -143,7 +132,7 @@ namespace Bonsai.Harp
                    8971 * FirmwareVersion.GetHashCode() +
                    2803 * CoreVersion.GetHashCode() +
                    691 * HardwareVersion.GetHashCode() +
-                   1409 * AssemblyNumber.GetHashCode() +
+                   1409 * AssemblyVersion.GetHashCode() +
                    2333 * PrereleaseVersion.GetHashCode();
         }
 
@@ -217,9 +206,9 @@ namespace Bonsai.Harp
                 var firmwareVersion = HarpVersion.Parse(match.Groups[2].Value);
                 var coreVersion = HarpVersion.Parse(match.Groups[3].Value);
                 var hardwareVersion = HarpVersion.Parse(match.Groups[4].Value);
-                var assemblyNumber = match.Groups[5].Value == HarpVersion.FloatingWildcard ? (int?)null : int.Parse(match.Groups[5].Value);
+                var assemblyVersion = match.Groups[5].Value == HarpVersion.FloatingWildcard ? (int?)null : int.Parse(match.Groups[5].Value);
                 var prereleaseVersion = string.IsNullOrEmpty(match.Groups[6].Value) ? (int?)null : int.Parse(match.Groups[6].Value);
-                metadata = new FirmwareMetadata(deviceName, firmwareVersion, coreVersion, hardwareVersion, assemblyNumber, prereleaseVersion);
+                metadata = new FirmwareMetadata(deviceName, firmwareVersion, coreVersion, hardwareVersion, assemblyVersion, prereleaseVersion);
                 return true;
             }
             else
@@ -238,7 +227,7 @@ namespace Bonsai.Harp
         public override string ToString()
         {
             var prerelease = PrereleaseVersion.HasValue ? $"-preview{PrereleaseVersion.Value}" : string.Empty;
-            var assemblyNumber = AssemblyNumber.HasValue ? AssemblyNumber.Value.ToString(CultureInfo.InvariantCulture) : HarpVersion.FloatingWildcard;
+            var assemblyNumber = AssemblyVersion.HasValue ? AssemblyVersion.Value.ToString(CultureInfo.InvariantCulture) : HarpVersion.FloatingWildcard;
             return $"{DeviceName}-fw{FirmwareVersion}-harp{CoreVersion}-hw{HardwareVersion}-ass{assemblyNumber}{prerelease}";
         }
     }

--- a/Bonsai.Harp/FirmwareMetadata.cs
+++ b/Bonsai.Harp/FirmwareMetadata.cs
@@ -70,6 +70,7 @@ namespace Bonsai.Harp
         public int? PrereleaseVersion { get; private set; }
 
         [Obsolete]
+        [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public HarpVersion ProtocolVersion


### PR DESCRIPTION
This PR rounds-up the new device configuration dialog with a port name selection drop-down to allow inspecting information from different devices and an improved bootloader for updating device firmware.

Fixes #31 