### PR TITLE
Refactor timestamped payload getter overloads

### DIFF
--- a/Bonsai.Harp/HarpMessage.cs
+++ b/Bonsai.Harp/HarpMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace Bonsai.Harp
 {
@@ -259,6 +260,8 @@ namespace Bonsai.Harp
             payloadLength = GetPayloadLength(payloadOffset);
         }
 
+        #region GetPayload
+
         /// <summary>
         /// Gets the array segment containing the raw message payload. This method
         /// returns a view into the original array without copying any data.
@@ -274,21 +277,24 @@ namespace Bonsai.Harp
         }
 
         /// <summary>
-        /// Gets the array segment containing the raw message payload and the timestamp. This method
-        /// returns a view into the original array without copying any data.
+        /// Gets the array segment containing the raw message payload and gets the message
+        /// timestamp. This method returns a view into the original array without copying
+        /// any data.
         /// </summary>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="ArraySegment{T}"/> delimiting the message payload section
+        /// An <see cref="ArraySegment{T}"/> delimiting the message payload section
         /// of the message bytes.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<ArraySegment<byte>> GetTimestampedPayload()
+        public ArraySegment<byte> GetPayload(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = new ArraySegment<byte>(MessageBytes, TimestampedOffset, GetPayloadLength(TimestampedOffset));
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return new ArraySegment<byte>(MessageBytes, TimestampedOffset, GetPayloadLength(TimestampedOffset));
         }
 
         /// <summary>
@@ -310,17 +316,20 @@ namespace Bonsai.Harp
         /// timestamp. The size of the type should be a multiple of the total size of the payload.
         /// </summary>
         /// <typeparam name="TArray">The type of the non-pointer values in the array.</typeparam>
-        /// <returns>A timestamped array containing a copy of the message payload data.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>An array containing a copy of the message payload data.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public unsafe Timestamped<TArray[]> GetTimestampedPayloadArray<TArray>() where TArray : unmanaged
+        public unsafe TArray[] GetPayloadArray<TArray>(out double timestamp) where TArray : unmanaged
         {
-            var timestamp = GetTimestamp();
+            timestamp = GetTimestamp();
             var payloadLength = GetPayloadLength(TimestampedOffset);
             var value = new TArray[payloadLength / sizeof(TArray)];
             Buffer.BlockCopy(MessageBytes, TimestampedOffset, value, 0, payloadLength);
-            return Timestamped.Create(value, timestamp);
+            return value;
         }
 
         /// <summary>
@@ -348,14 +357,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single 8-bit unsigned integer and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="byte"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>A <see cref="byte"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<byte> GetTimestampedPayloadByte()
+        public byte GetPayloadByte(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            return Timestamped.Create(MessageBytes[TimestampedOffset], timestamp);
+            timestamp = GetTimestamp();
+            return MessageBytes[TimestampedOffset];
         }
 
         /// <summary>
@@ -363,17 +375,20 @@ namespace Bonsai.Harp
         /// and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="byte"/> representing the element at the specified index
-        /// of the array payload.
+        /// A <see cref="byte"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<byte> GetTimestampedPayloadByte(int index)
+        public byte GetPayloadByte(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            return Timestamped.Create(MessageBytes[TimestampedOffset + index], timestamp);
+            timestamp = GetTimestamp();
+            return MessageBytes[TimestampedOffset + index];
         }
 
         /// <summary>
@@ -401,14 +416,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single 8-bit signed integer and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="sbyte"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>An <see cref="sbyte"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<sbyte> GetTimestampedPayloadSByte()
+        public sbyte GetPayloadSByte(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            return Timestamped.Create((sbyte)MessageBytes[TimestampedOffset], timestamp);
+            timestamp = GetTimestamp();
+            return (sbyte)MessageBytes[TimestampedOffset];
         }
 
         /// <summary>
@@ -416,17 +434,20 @@ namespace Bonsai.Harp
         /// and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="sbyte"/> representing the element at the specified index
-        /// of the array payload.
+        /// An <see cref="sbyte"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<sbyte> GetTimestampedPayloadSByte(int index)
+        public sbyte GetPayloadSByte(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            return Timestamped.Create((sbyte)MessageBytes[TimestampedOffset + index], timestamp);
+            timestamp = GetTimestamp();
+            return (sbyte)MessageBytes[TimestampedOffset + index];
         }
 
         /// <summary>
@@ -454,15 +475,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single 16-bit unsigned integer and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="ushort"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>A <see cref="ushort"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<ushort> GetTimestampedPayloadUInt16()
+        public ushort GetPayloadUInt16(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToUInt16(MessageBytes, TimestampedOffset);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToUInt16(MessageBytes, TimestampedOffset);
         }
 
         /// <summary>
@@ -470,18 +493,20 @@ namespace Bonsai.Harp
         /// and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="ushort"/> representing the element at the specified index
-        /// of the array payload.
+        /// A <see cref="ushort"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<ushort> GetTimestampedPayloadUInt16(int index)
+        public ushort GetPayloadUInt16(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToUInt16(MessageBytes, TimestampedOffset + sizeof(ushort) * index);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToUInt16(MessageBytes, TimestampedOffset + sizeof(ushort) * index);
         }
 
         /// <summary>
@@ -509,15 +534,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single 16-bit signed integer and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="short"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>A <see cref="short"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<short> GetTimestampedPayloadInt16()
+        public short GetPayloadInt16(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToInt16(MessageBytes, TimestampedOffset);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToInt16(MessageBytes, TimestampedOffset);
         }
 
         /// <summary>
@@ -525,18 +552,20 @@ namespace Bonsai.Harp
         /// and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="short"/> representing the element at the specified index
-        /// of the array payload.
+        /// A <see cref="short"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<short> GetTimestampedPayloadInt16(int index)
+        public short GetPayloadInt16(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToInt16(MessageBytes, TimestampedOffset + sizeof(short) * index);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToInt16(MessageBytes, TimestampedOffset + sizeof(short) * index);
         }
 
         /// <summary>
@@ -564,15 +593,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single 32-bit unsigned integer and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="uint"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>A <see cref="uint"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<uint> GetTimestampedPayloadUInt32()
+        public uint GetPayloadUInt32(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToUInt32(MessageBytes, TimestampedOffset);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToUInt32(MessageBytes, TimestampedOffset);
         }
 
         /// <summary>
@@ -580,18 +611,20 @@ namespace Bonsai.Harp
         /// and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="uint"/> representing the element at the specified index
-        /// of the array payload.
+        /// A <see cref="uint"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<uint> GetTimestampedPayloadUInt32(int index)
+        public uint GetPayloadUInt32(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToUInt32(MessageBytes, TimestampedOffset + sizeof(uint) * index);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToUInt32(MessageBytes, TimestampedOffset + sizeof(uint) * index);
         }
 
         /// <summary>
@@ -619,15 +652,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single 32-bit signed integer and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="int"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>An <see cref="int"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<int> GetTimestampedPayloadInt32()
+        public int GetPayloadInt32(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToInt32(MessageBytes, TimestampedOffset);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToInt32(MessageBytes, TimestampedOffset);
         }
 
         /// <summary>
@@ -635,18 +670,20 @@ namespace Bonsai.Harp
         /// and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="int"/> representing the element at the specified index
-        /// of the array payload.
+        /// An <see cref="int"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<int> GetTimestampedPayloadInt32(int index)
+        public int GetPayloadInt32(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToInt32(MessageBytes, TimestampedOffset + sizeof(int) * index);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToInt32(MessageBytes, TimestampedOffset + sizeof(int) * index);
         }
 
         /// <summary>
@@ -674,15 +711,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single 64-bit unsigned integer and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="ulong"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>A <see cref="ulong"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<ulong> GetTimestampedPayloadUInt64()
+        public ulong GetPayloadUInt64(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToUInt64(MessageBytes, TimestampedOffset);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToUInt64(MessageBytes, TimestampedOffset);
         }
 
         /// <summary>
@@ -690,18 +729,20 @@ namespace Bonsai.Harp
         /// and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="ulong"/> representing the element at the specified index
-        /// of the array payload.
+        /// A <see cref="ulong"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<ulong> GetTimestampedPayloadUInt64(int index)
+        public ulong GetPayloadUInt64(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToUInt64(MessageBytes, TimestampedOffset + sizeof(ulong) * index);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToUInt64(MessageBytes, TimestampedOffset + sizeof(ulong) * index);
         }
 
         /// <summary>
@@ -729,15 +770,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single 64-bit signed integer and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="long"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>A <see cref="long"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<long> GetTimestampedPayloadInt64()
+        public long GetPayloadInt64(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToInt64(MessageBytes, TimestampedOffset);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToInt64(MessageBytes, TimestampedOffset);
         }
 
         /// <summary>
@@ -745,18 +788,20 @@ namespace Bonsai.Harp
         /// and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="long"/> representing the element at the specified index
-        /// of the array payload.
+        /// A <see cref="long"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<long> GetTimestampedPayloadInt64(int index)
+        public long GetPayloadInt64(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToInt64(MessageBytes, TimestampedOffset + sizeof(long) * index);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToInt64(MessageBytes, TimestampedOffset + sizeof(long) * index);
         }
 
         /// <summary>
@@ -784,15 +829,17 @@ namespace Bonsai.Harp
         /// <summary>
         /// Returns the message payload as a single-precision floating point number and gets the message timestamp.
         /// </summary>
-        /// <returns>A timestamped <see cref="float"/> representing the message payload.</returns>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
+        /// <returns>A <see cref="float"/> representing the message payload.</returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<float> GetTimestampedPayloadSingle()
+        public float GetPayloadSingle(out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToSingle(MessageBytes, TimestampedOffset);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToSingle(MessageBytes, TimestampedOffset);
         }
 
         /// <summary>
@@ -800,18 +847,20 @@ namespace Bonsai.Harp
         /// payload and gets the message timestamp.
         /// </summary>
         /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <param name="timestamp">
+        /// When this method returns, contains the message timestamp, in seconds.
+        /// </param>
         /// <returns>
-        /// A timestamped <see cref="float"/> representing the element at the specified index
-        /// of the array payload.
+        /// A <see cref="float"/> representing the element at the specified index of the
+        /// array payload.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The message does not have a timestamped payload.
         /// </exception>
-        public Timestamped<float> GetTimestampedPayloadSingle(int index)
+        public float GetPayloadSingle(int index, out double timestamp)
         {
-            var timestamp = GetTimestamp();
-            var value = BitConverter.ToSingle(MessageBytes, TimestampedOffset + sizeof(float) * index);
-            return Timestamped.Create(value, timestamp);
+            timestamp = GetTimestamp();
+            return BitConverter.ToSingle(MessageBytes, TimestampedOffset + sizeof(float) * index);
         }
 
         /// <summary>
@@ -898,6 +947,10 @@ namespace Bonsai.Harp
             var payloadLength = GetPayloadLength(TimestampedOffset);
             Buffer.BlockCopy(MessageBytes, TimestampedOffset, value, index * sizeof(TArray), payloadLength);
         }
+
+        #endregion
+
+        #region FromPayload
 
         static HarpMessage FromBytes(double timestamp, params byte[] messageBytes)
         {
@@ -2364,5 +2417,342 @@ namespace Bonsai.Harp
                 timestamped ? timestamp.ToString("@0.#####") : string.Empty,
                 payloadLength);
         }
+
+        #endregion
+
+        #region Legacy API
+
+        /// <summary>
+        /// Gets the array segment containing the raw message payload and the timestamp. This method
+        /// returns a view into the original array without copying any data.
+        /// </summary>
+        /// <returns>
+        /// A timestamped <see cref="ArraySegment{T}"/> delimiting the message payload section
+        /// of the message bytes.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<ArraySegment<byte>> GetTimestampedPayload()
+        {
+            return Timestamped.Create(GetPayload(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as an array of non-pointer value types and gets the message
+        /// timestamp. The size of the type should be a multiple of the total size of the payload.
+        /// </summary>
+        /// <typeparam name="TArray">The type of the non-pointer values in the array.</typeparam>
+        /// <returns>A timestamped array containing a copy of the message payload data.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public unsafe Timestamped<TArray[]> GetTimestampedPayloadArray<TArray>() where TArray : unmanaged
+        {
+            return Timestamped.Create(GetPayloadArray<TArray>(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single 8-bit unsigned integer and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="byte"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<byte> GetTimestampedPayloadByte()
+        {
+            return Timestamped.Create(GetPayloadByte(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the 8-bit unsigned integer array payload
+        /// and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="byte"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<byte> GetTimestampedPayloadByte(int index)
+        {
+            return Timestamped.Create(GetPayloadByte(index, out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single 8-bit signed integer and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="sbyte"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<sbyte> GetTimestampedPayloadSByte()
+        {
+            return Timestamped.Create(GetPayloadSByte(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the 8-bit signed integer array payload
+        /// and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="sbyte"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<sbyte> GetTimestampedPayloadSByte(int index)
+        {
+            return Timestamped.Create(GetPayloadSByte(index, out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single 16-bit unsigned integer and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="ushort"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<ushort> GetTimestampedPayloadUInt16()
+        {
+            return Timestamped.Create(GetPayloadUInt16(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the 16-bit unsigned integer array payload
+        /// and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="ushort"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<ushort> GetTimestampedPayloadUInt16(int index)
+        {
+            return Timestamped.Create(GetPayloadUInt16(index, out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single 16-bit signed integer and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="short"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<short> GetTimestampedPayloadInt16()
+        {
+            return Timestamped.Create(GetPayloadInt16(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the 16-bit signed integer array payload
+        /// and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="short"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<short> GetTimestampedPayloadInt16(int index)
+        {
+            return Timestamped.Create(GetPayloadInt16(index, out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single 32-bit unsigned integer and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="uint"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<uint> GetTimestampedPayloadUInt32()
+        {
+            return Timestamped.Create(GetPayloadUInt32(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the 32-bit unsigned integer array payload
+        /// and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="uint"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<uint> GetTimestampedPayloadUInt32(int index)
+        {
+            return Timestamped.Create(GetPayloadUInt32(index, out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single 32-bit signed integer and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="int"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<int> GetTimestampedPayloadInt32()
+        {
+            return Timestamped.Create(GetPayloadInt32(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the 32-bit signed integer array payload
+        /// and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="int"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<int> GetTimestampedPayloadInt32(int index)
+        {
+            return Timestamped.Create(GetPayloadInt32(index, out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single 64-bit unsigned integer and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="ulong"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<ulong> GetTimestampedPayloadUInt64()
+        {
+            return Timestamped.Create(GetPayloadUInt64(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the 64-bit unsigned integer array payload
+        /// and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="ulong"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<ulong> GetTimestampedPayloadUInt64(int index)
+        {
+            return Timestamped.Create(GetPayloadUInt64(index, out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single 64-bit signed integer and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="long"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<long> GetTimestampedPayloadInt64()
+        {
+            return Timestamped.Create(GetPayloadInt64(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the 64-bit signed integer array payload
+        /// and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="long"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<long> GetTimestampedPayloadInt64(int index)
+        {
+            return Timestamped.Create(GetPayloadInt64(index, out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the message payload as a single-precision floating point number and gets the message timestamp.
+        /// </summary>
+        /// <returns>A timestamped <see cref="float"/> representing the message payload.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<float> GetTimestampedPayloadSingle()
+        {
+            return Timestamped.Create(GetPayloadSingle(out double timestamp), timestamp);
+        }
+
+        /// <summary>
+        /// Returns the element at the specified index of the single-precision floating point array
+        /// payload and gets the message timestamp.
+        /// </summary>
+        /// <param name="index">The zero-based index of the array element to get.</param>
+        /// <returns>
+        /// A timestamped <see cref="float"/> representing the element at the specified index
+        /// of the array payload.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The message does not have a timestamped payload.
+        /// </exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Timestamped<float> GetTimestampedPayloadSingle(int index)
+        {
+            return Timestamped.Create(GetPayloadSingle(index, out double timestamp), timestamp);
+        }
+
+        #endregion
     }
 }

--- a/Bonsai.Harp/Parse.cs
+++ b/Bonsai.Harp/Parse.cs
@@ -135,7 +135,7 @@ namespace Bonsai.Harp
 
         static Timestamped<TArray[]> ProcessTimestampedArray<TArray>(HarpMessage input) where TArray : unmanaged
         {
-            return input.GetTimestampedPayloadArray<TArray>();
+            return Timestamped.Create(input.GetPayloadArray<TArray>(out double timestamp), timestamp);
         }
 
         static byte ProcessU8(HarpMessage input)
@@ -147,7 +147,7 @@ namespace Bonsai.Harp
         static Timestamped<byte> ProcessTimestampedU8(HarpMessage input)
         {
             CheckErrors(input, PayloadType.U8);
-            return input.GetTimestampedPayloadByte();
+            return Timestamped.Create(input.GetPayloadByte(out double timestamp), timestamp);
         }
 
         static sbyte ProcessS8(HarpMessage input)
@@ -159,7 +159,7 @@ namespace Bonsai.Harp
         static Timestamped<sbyte> ProcessTimestampedS8(HarpMessage input)
         {
             CheckErrors(input, PayloadType.S8);
-            return input.GetTimestampedPayloadSByte();
+            return Timestamped.Create(input.GetPayloadSByte(out double timestamp), timestamp);
         }
 
         static ushort ProcessU16(HarpMessage input)
@@ -171,7 +171,7 @@ namespace Bonsai.Harp
         static Timestamped<ushort> ProcessTimestampedU16(HarpMessage input)
         {
             CheckErrors(input, PayloadType.U16);
-            return input.GetTimestampedPayloadUInt16();
+            return Timestamped.Create(input.GetPayloadUInt16(out double timestamp), timestamp);
         }
 
         static short ProcessS16(HarpMessage input)
@@ -183,7 +183,7 @@ namespace Bonsai.Harp
         static Timestamped<short> ProcessTimestampedS16(HarpMessage input)
         {
             CheckErrors(input, PayloadType.S16);
-            return input.GetTimestampedPayloadInt16();
+            return Timestamped.Create(input.GetPayloadInt16(out double timestamp), timestamp);
         }
 
         static uint ProcessU32(HarpMessage input)
@@ -195,7 +195,7 @@ namespace Bonsai.Harp
         static Timestamped<uint> ProcessTimestampedU32(HarpMessage input)
         {
             CheckErrors(input, PayloadType.U32);
-            return input.GetTimestampedPayloadUInt32();
+            return Timestamped.Create(input.GetPayloadUInt32(out double timestamp), timestamp);
         }
 
         static int ProcessS32(HarpMessage input)
@@ -207,7 +207,7 @@ namespace Bonsai.Harp
         static Timestamped<int> ProcessTimestampedS32(HarpMessage input)
         {
             CheckErrors(input, PayloadType.S32);
-            return input.GetTimestampedPayloadInt32();
+            return Timestamped.Create(input.GetPayloadInt32(out double timestamp), timestamp);
         }
 
         static ulong ProcessU64(HarpMessage input)
@@ -219,7 +219,7 @@ namespace Bonsai.Harp
         static Timestamped<ulong> ProcessTimestampedU64(HarpMessage input)
         {
             CheckErrors(input, PayloadType.U64);
-            return input.GetTimestampedPayloadUInt64();
+            return Timestamped.Create(input.GetPayloadUInt64(out double timestamp), timestamp);
         }
 
         static long ProcessS64(HarpMessage input)
@@ -231,7 +231,7 @@ namespace Bonsai.Harp
         static Timestamped<long> ProcessTimestampedS64(HarpMessage input)
         {
             CheckErrors(input, PayloadType.S64);
-            return input.GetTimestampedPayloadInt64();
+            return Timestamped.Create(input.GetPayloadInt64(out double timestamp), timestamp);
         }
 
         static float ProcessFloat(HarpMessage input)
@@ -243,7 +243,7 @@ namespace Bonsai.Harp
         static Timestamped<float> ProcessTimestampedFloat(HarpMessage input)
         {
             CheckErrors(input, PayloadType.Float);
-            return input.GetTimestampedPayloadSingle();
+            return Timestamped.Create(input.GetPayloadSingle(out double timestamp), timestamp);
         }
 
         static double ProcessTimestamp(HarpMessage input)


### PR DESCRIPTION
This PR refactors the signature of the `GetTimestampedPayload` variants to use an optional `out` parameter. This has the advantage of being more easily discoverable as a variant of `GetPayload`, allowing easier composition with payload conversion operations (does not require reconstruction of timestamped structure) and is consistent with the `CopyTo` payload variant.

However, it does imply deprecating existing signatures and keeping legacy API compatibility until at least the next major release.

Fixes #34 