### PR TITLE
Resolve issues with Device base class XML namespace and default editor name

### DIFF
--- a/Bonsai.Harp/Constants.cs
+++ b/Bonsai.Harp/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Bonsai.Harp
+{
+    static class Constants
+    {
+        public const string XmlNamespace = "clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp";
+    }
+}

--- a/Bonsai.Harp/Device.cs
+++ b/Bonsai.Harp/Device.cs
@@ -233,7 +233,7 @@ namespace Bonsai.Harp
             });
         }
 
-        string INamedElement.Name => !string.IsNullOrEmpty(name) ? name : nameof(Device);
+        string INamedElement.Name => !string.IsNullOrEmpty(name) ? name : default;
 
         SerialTransport CreateTransport(IObserver<HarpMessage> observer)
         {

--- a/Bonsai.Harp/Device.cs
+++ b/Bonsai.Harp/Device.cs
@@ -5,12 +5,14 @@ using System.Reactive.Linq;
 using System.Reactive;
 using System.Text;
 using System.Reactive.Concurrency;
+using System.Xml.Serialization;
 
 namespace Bonsai.Harp
 {
     /// <summary>
     /// Represents an observable source of messages from the Harp device connected at the specified serial port.
     /// </summary>
+    [XmlType(Namespace = Constants.XmlNamespace)]
     [Editor("Bonsai.Harp.Design.DeviceConfigurationEditor, Bonsai.Harp.Design", typeof(ComponentEditor))]
     [Description("Produces a sequence of messages from the Harp device connected at the specified serial port.")]
     public class Device : Source<HarpMessage>, INamedElement


### PR DESCRIPTION
This PR resolves issues with the `Device` base class to improve behavior of derived classes with respect to XML serialization and editor naming. The XML namespace is now fixed to `Bonsai.Harp` and the default value is used when implementing `INamedElement` to allow default device name to match the derived class name.

Fixes #44 
Fixes #41 