### PR TITLE
Allow forced updates to escape to bootloader mode

### DIFF
--- a/Bonsai.Harp/Bootloader.cs
+++ b/Bonsai.Harp/Bootloader.cs
@@ -74,7 +74,7 @@ namespace Bonsai.Harp
                     const byte ResetDefault = 0x1;
                     const byte ResetEeprom = 0x2;
                     progress?.Report(20);
-                    var reset = await device.ReadByteAsync(DeviceRegisters.ResetDevice);
+                    var reset = await device.ReadByteAsync(DeviceRegisters.ResetDevice).WithTimeout(FlushDelayMilliseconds);
                     if ((reset & BootEeprom) != 0)
                     {
                         await device.WriteByteAsync(DeviceRegisters.ResetDevice, ResetEeprom);


### PR DESCRIPTION
This PR adds a timeout when reading the reset register to allow forced updates to escape directly into bootloader mode. This will allow devices which are locked in bootloader mode to be flashed using the device setup editor.

Fixes #47 