### PR TITLE
Refactor core operators to pull logic out of generated register types

### DIFF
--- a/Bonsai.Harp.Tests/TestFirmwareMetadata.cs
+++ b/Bonsai.Harp.Tests/TestFirmwareMetadata.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Threading.Tasks;
 
 namespace Bonsai.Harp.Tests
 {

--- a/Bonsai.Harp/Bonsai.Harp.csproj
+++ b/Bonsai.Harp/Bonsai.Harp.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <Title>Bonsai - Harp Library</Title>
     <Description>Bonsai Library containing interfaces for data acquisition and control of devices implementing the Harp protocol.</Description>
-    <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>
     <PackageTags>Bonsai Rx Harp Hardware Protocol</PackageTags>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <VersionPrefix>3.5.0</VersionPrefix>
   </PropertyGroup>
 

--- a/Bonsai.Harp/CommandBuilder.cs
+++ b/Bonsai.Harp/CommandBuilder.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq.Expressions;
+using Bonsai.Expressions;
 
 namespace Bonsai.Harp
 {
@@ -11,6 +14,8 @@ namespace Bonsai.Harp
     [DefaultProperty(nameof(Command))]
     public abstract class CommandBuilder : HarpCombinatorBuilder, INamedElement
     {
+        readonly CombinatorBuilder builder = new CombinatorBuilder();
+
         string INamedElement.Name => $"{RemoveSuffix(GetType().Name, nameof(Command))}.{GetElementDisplayName(Command)}";
 
         /// <summary>
@@ -25,8 +30,17 @@ namespace Bonsai.Harp
         [TypeConverter(typeof(CombinatorTypeConverter))]
         public object Command
         {
-            get { return Combinator; }
-            set { Combinator = value; }
+            get { return Operator; }
+            set { builder.Combinator = Operator = value; }
+        }
+
+        /// <inheritdoc/>
+        public override Range<int> ArgumentRange => builder.ArgumentRange;
+
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return builder.Build(arguments);
         }
     }
 }

--- a/Bonsai.Harp/CreateMessage.cs
+++ b/Bonsai.Harp/CreateMessage.cs
@@ -8,24 +8,42 @@ using System.Xml.Serialization;
 namespace Bonsai.Harp
 {
     /// <summary>
-    /// Represents an operator which creates standard message payloads for
-    /// Harp devices.
+    /// Represents an operator which creates a sequence of standard message payloads
+    /// for Harp devices.
     /// </summary>
     /// <seealso cref="CreateMessagePayload"/>
+    /// <seealso cref="CreateWhoAmIPayload"/>
+    /// <seealso cref="CreateHardwareVersionHighPayload"/>
+    /// <seealso cref="CreateHardwareVersionLowPayload"/>
+    /// <seealso cref="CreateAssemblyVersionPayload"/>
+    /// <seealso cref="CreateCoreVersionHighPayload"/>
+    /// <seealso cref="CreateCoreVersionLowPayload"/>
+    /// <seealso cref="CreateFirmwareVersionHighPayload"/>
+    /// <seealso cref="CreateFirmwareVersionLowPayload"/>
     /// <seealso cref="CreateTimestampSecondsPayload"/>
+    /// <seealso cref="CreateTimestampMicrosecondsPayload"/>
     /// <seealso cref="CreateOperationControlPayload"/>
     /// <seealso cref="CreateResetDevicePayload"/>
     /// <seealso cref="CreateDeviceNamePayload"/>
     /// <seealso cref="CreateSerialNumberPayload"/>
     /// <seealso cref="CreateClockConfigurationPayload"/>
     [XmlInclude(typeof(CreateMessagePayload))]
+    [XmlInclude(typeof(CreateWhoAmIPayload))]
+    [XmlInclude(typeof(CreateHardwareVersionHighPayload))]
+    [XmlInclude(typeof(CreateHardwareVersionLowPayload))]
+    [XmlInclude(typeof(CreateAssemblyVersionPayload))]
+    [XmlInclude(typeof(CreateCoreVersionHighPayload))]
+    [XmlInclude(typeof(CreateCoreVersionLowPayload))]
+    [XmlInclude(typeof(CreateFirmwareVersionHighPayload))]
+    [XmlInclude(typeof(CreateFirmwareVersionLowPayload))]
     [XmlInclude(typeof(CreateTimestampSecondsPayload))]
+    [XmlInclude(typeof(CreateTimestampMicrosecondsPayload))]
     [XmlInclude(typeof(CreateOperationControlPayload))]
     [XmlInclude(typeof(CreateResetDevicePayload))]
     [XmlInclude(typeof(CreateDeviceNamePayload))]
     [XmlInclude(typeof(CreateSerialNumberPayload))]
     [XmlInclude(typeof(CreateClockConfigurationPayload))]
-    [Description("Creates standard message payloads for Harp devices.")]
+    [Description("Creates a sequence of standard message payloads for Harp devices.")]
     public class CreateMessage : CreateMessageBuilder, INamedElement
     {
         /// <summary>
@@ -53,7 +71,7 @@ namespace Bonsai.Harp
                 if (base.Payload is CreateMessagePayload createMessage &&
                     value is XmlNode[] xmlNode && xmlNode.Length == 1)
                 {
-                    createMessage.Payload = double.Parse(xmlNode[0].InnerText);
+                    createMessage.Value = double.Parse(xmlNode[0].InnerText);
                 }
                 else base.Payload = value;
             }
@@ -103,56 +121,46 @@ namespace Bonsai.Harp
     }
 
     /// <summary>
-    /// Represents an operator which creates an observable source of Harp messages.
+    /// Represents an operator which creates a sequence of Harp messages with
+    /// the specified payload.
     /// </summary>
     [DesignTimeVisible(false)]
-    [Description("Creates a new Harp message with the specified payload.")]
+    [Description("Creates a sequence of Harp messages with the specified payload.")]
     public class CreateMessagePayload : Source<HarpMessage>
     {
-        double payload;
-        event Action<double> PayloadChanged;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CreateMessagePayload"/> class.
-        /// </summary>
-        public CreateMessagePayload()
-        {
-            Address = 32;
-            MessageType = MessageType.Write;
-            PayloadType = PayloadType.U8;
-            Payload = 0;
-        }
+        double value;
+        event Action<double> ValueChanged;
 
         /// <summary>
         /// Gets or sets the type of the Harp message.
         /// </summary>
         [Category(nameof(CategoryAttribute.Design))]
         [Description("The type of the Harp message.")]
-        public MessageType MessageType { get; set; }
+        public MessageType MessageType { get; set; } = MessageType.Write;
 
         /// <summary>
         /// Gets or sets the address of the register to which the Harp message refers to.
         /// </summary>
         [Description("The address of the register to which the Harp message refers to.")]
-        public int Address { get; set; }
+        public int Address { get; set; } = 32;
 
         /// <summary>
         /// Gets or sets the type of data to include in the message payload.
         /// </summary>
         [Description("The type of data to include in the message payload.")]
-        public PayloadType PayloadType { get; set; }
+        public PayloadType PayloadType { get; set; } = PayloadType.U8;
 
         /// <summary>
         /// Gets or sets the data to write in the message payload.
         /// </summary>
         [Description("The data to write in the message payload.")]
-        public double Payload
+        public double Value
         {
-            get { return payload; }
+            get { return value; }
             set
             {
-                this.payload = value;
-                PayloadChanged?.Invoke(value);
+                this.value = value;
+                ValueChanged?.Invoke(value);
             }
         }
 
@@ -187,10 +195,10 @@ namespace Bonsai.Harp
         public override IObservable<HarpMessage> Generate()
         {
             return Observable
-                .Defer(() => Observable.Return(GetMessage(payload)))
+                .Defer(() => Observable.Return(GetMessage(value)))
                 .Concat(Observable.FromEvent<double>(
-                    handler => PayloadChanged += handler,
-                    handler => PayloadChanged -= handler)
+                    handler => ValueChanged += handler,
+                    handler => ValueChanged -= handler)
                 .Select(payload => GetMessage(payload)));
         }
 
@@ -205,7 +213,7 @@ namespace Bonsai.Harp
         /// </returns>
         public IObservable<HarpMessage> Generate<TSource>(IObservable<TSource> source)
         {
-            return source.Select(x => GetMessage(payload));
+            return source.Select(x => GetMessage(value));
         }
     }
 }

--- a/Bonsai.Harp/CreateMessageBuilder.cs
+++ b/Bonsai.Harp/CreateMessageBuilder.cs
@@ -1,5 +1,8 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq.Expressions;
 using System.Xml.Serialization;
+using Bonsai.Expressions;
 
 namespace Bonsai.Harp
 {
@@ -12,6 +15,8 @@ namespace Bonsai.Harp
     [WorkflowElementCategory(ElementCategory.Source)]
     public abstract class CreateMessageBuilder : HarpCombinatorBuilder
     {
+        readonly CombinatorBuilder builder = new CombinatorBuilder();
+
         /// <summary>
         /// Gets or sets the operator used to create specific Harp device message payloads.
         /// </summary>
@@ -23,8 +28,17 @@ namespace Bonsai.Harp
         [TypeConverter(typeof(CombinatorTypeConverter))]
         public object Payload
         {
-            get { return Combinator; }
-            set { Combinator = value; }
+            get { return Operator; }
+            set { builder.Combinator = Operator = value; }
+        }
+
+        /// <inheritdoc/>
+        public override Range<int> ArgumentRange => builder.ArgumentRange;
+
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return builder.Build(arguments);
         }
     }
 }

--- a/Bonsai.Harp/Device.Generated.cs
+++ b/Bonsai.Harp/Device.Generated.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reactive.Linq;
@@ -32,10 +32,10 @@ namespace Bonsai.Harp
     }
 
     /// <summary>
-    /// Represents an operator that specifies the identity class of the device.
+    /// Represents a register that specifies the identity class of the device.
     /// </summary>
     [Description("Specifies the identity class of the device.")]
-    public partial class WhoAmI : HarpCombinator
+    public partial class WhoAmI
     {
         /// <summary>
         /// Represents the address of the <see cref="WhoAmI"/> register. This field is constant.
@@ -51,14 +51,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="WhoAmI"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WhoAmI"/> class.
-        /// </summary>
-        public WhoAmI()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="WhoAmI"/> register messages.
@@ -110,83 +102,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, (ushort)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="WhoAmI"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="int"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<int> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="WhoAmI"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="int"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="WhoAmI"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<int> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="WhoAmI"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="int"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="WhoAmI"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<int>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the WhoAmI register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// WhoAmI register.
     /// </summary>
+    /// <seealso cref="WhoAmI"/>
     [Description("Filters and selects timestamped messages from the WhoAmI register.")]
-    public partial class TimestampedWhoAmI : HarpCombinator
+    public partial class TimestampedWhoAmI
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="WhoAmI"/> register.
+        /// Represents the address of the <see cref="WhoAmI"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="int"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<int>> Process(IObservable<HarpMessage> source)
+        public const int Address = WhoAmI.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="WhoAmI"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<int> GetPayload(HarpMessage message)
         {
-            return source.Where(WhoAmI.Address, MessageType).Select(WhoAmI.GetTimestampedPayload);
+            return WhoAmI.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the major hardware version of the device.
+    /// Represents a register that specifies the major hardware version of the device.
     /// </summary>
     [Description("Specifies the major hardware version of the device.")]
-    public partial class HardwareVersionHigh : HarpCombinator
+    public partial class HardwareVersionHigh
     {
         /// <summary>
         /// Represents the address of the <see cref="HardwareVersionHigh"/> register. This field is constant.
@@ -202,14 +148,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="HardwareVersionHigh"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HardwareVersionHigh"/> class.
-        /// </summary>
-        public HardwareVersionHigh()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="HardwareVersionHigh"/> register messages.
@@ -260,83 +198,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="HardwareVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="HardwareVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="HardwareVersionHigh"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="HardwareVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="HardwareVersionHigh"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the HardwareVersionHigh register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// HardwareVersionHigh register.
     /// </summary>
+    /// <seealso cref="HardwareVersionHigh"/>
     [Description("Filters and selects timestamped messages from the HardwareVersionHigh register.")]
-    public partial class TimestampedHardwareVersionHigh : HarpCombinator
+    public partial class TimestampedHardwareVersionHigh
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="HardwareVersionHigh"/> register.
+        /// Represents the address of the <see cref="HardwareVersionHigh"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = HardwareVersionHigh.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="HardwareVersionHigh"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(HardwareVersionHigh.Address, MessageType).Select(HardwareVersionHigh.GetTimestampedPayload);
+            return HardwareVersionHigh.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the minor hardware version of the device.
+    /// Represents a register that specifies the minor hardware version of the device.
     /// </summary>
     [Description("Specifies the minor hardware version of the device.")]
-    public partial class HardwareVersionLow : HarpCombinator
+    public partial class HardwareVersionLow
     {
         /// <summary>
         /// Represents the address of the <see cref="HardwareVersionLow"/> register. This field is constant.
@@ -352,14 +244,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="HardwareVersionLow"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HardwareVersionLow"/> class.
-        /// </summary>
-        public HardwareVersionLow()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="HardwareVersionLow"/> register messages.
@@ -410,83 +294,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="HardwareVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="HardwareVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="HardwareVersionLow"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="HardwareVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="HardwareVersionLow"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the HardwareVersionLow register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// HardwareVersionLow register.
     /// </summary>
+    /// <seealso cref="HardwareVersionLow"/>
     [Description("Filters and selects timestamped messages from the HardwareVersionLow register.")]
-    public partial class TimestampedHardwareVersionLow : HarpCombinator
+    public partial class TimestampedHardwareVersionLow
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="HardwareVersionLow"/> register.
+        /// Represents the address of the <see cref="HardwareVersionLow"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = HardwareVersionLow.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="HardwareVersionLow"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(HardwareVersionLow.Address, MessageType).Select(HardwareVersionLow.GetTimestampedPayload);
+            return HardwareVersionLow.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the version of the assembled components in the device.
+    /// Represents a register that specifies the version of the assembled components in the device.
     /// </summary>
     [Description("Specifies the version of the assembled components in the device.")]
-    public partial class AssemblyVersion : HarpCombinator
+    public partial class AssemblyVersion
     {
         /// <summary>
         /// Represents the address of the <see cref="AssemblyVersion"/> register. This field is constant.
@@ -502,14 +340,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="AssemblyVersion"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AssemblyVersion"/> class.
-        /// </summary>
-        public AssemblyVersion()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="AssemblyVersion"/> register messages.
@@ -560,83 +390,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="AssemblyVersion"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="AssemblyVersion"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="AssemblyVersion"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="AssemblyVersion"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="AssemblyVersion"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the AssemblyVersion register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// AssemblyVersion register.
     /// </summary>
+    /// <seealso cref="AssemblyVersion"/>
     [Description("Filters and selects timestamped messages from the AssemblyVersion register.")]
-    public partial class TimestampedAssemblyVersion : HarpCombinator
+    public partial class TimestampedAssemblyVersion
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="AssemblyVersion"/> register.
+        /// Represents the address of the <see cref="AssemblyVersion"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = AssemblyVersion.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="AssemblyVersion"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(AssemblyVersion.Address, MessageType).Select(AssemblyVersion.GetTimestampedPayload);
+            return AssemblyVersion.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the major version of the Harp core implemented by the device.
+    /// Represents a register that specifies the major version of the Harp core implemented by the device.
     /// </summary>
     [Description("Specifies the major version of the Harp core implemented by the device.")]
-    public partial class CoreVersionHigh : HarpCombinator
+    public partial class CoreVersionHigh
     {
         /// <summary>
         /// Represents the address of the <see cref="CoreVersionHigh"/> register. This field is constant.
@@ -652,14 +436,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="CoreVersionHigh"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CoreVersionHigh"/> class.
-        /// </summary>
-        public CoreVersionHigh()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="CoreVersionHigh"/> register messages.
@@ -710,83 +486,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="CoreVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="CoreVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="CoreVersionHigh"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="CoreVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="CoreVersionHigh"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the CoreVersionHigh register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// CoreVersionHigh register.
     /// </summary>
+    /// <seealso cref="CoreVersionHigh"/>
     [Description("Filters and selects timestamped messages from the CoreVersionHigh register.")]
-    public partial class TimestampedCoreVersionHigh : HarpCombinator
+    public partial class TimestampedCoreVersionHigh
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="CoreVersionHigh"/> register.
+        /// Represents the address of the <see cref="CoreVersionHigh"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = CoreVersionHigh.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="CoreVersionHigh"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(CoreVersionHigh.Address, MessageType).Select(CoreVersionHigh.GetTimestampedPayload);
+            return CoreVersionHigh.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the minor version of the Harp core implemented by the device.
+    /// Represents a register that specifies the minor version of the Harp core implemented by the device.
     /// </summary>
     [Description("Specifies the minor version of the Harp core implemented by the device.")]
-    public partial class CoreVersionLow : HarpCombinator
+    public partial class CoreVersionLow
     {
         /// <summary>
         /// Represents the address of the <see cref="CoreVersionLow"/> register. This field is constant.
@@ -802,14 +532,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="CoreVersionLow"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CoreVersionLow"/> class.
-        /// </summary>
-        public CoreVersionLow()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="CoreVersionLow"/> register messages.
@@ -860,83 +582,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="CoreVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="CoreVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="CoreVersionLow"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="CoreVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="CoreVersionLow"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the CoreVersionLow register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// CoreVersionLow register.
     /// </summary>
+    /// <seealso cref="CoreVersionLow"/>
     [Description("Filters and selects timestamped messages from the CoreVersionLow register.")]
-    public partial class TimestampedCoreVersionLow : HarpCombinator
+    public partial class TimestampedCoreVersionLow
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="CoreVersionLow"/> register.
+        /// Represents the address of the <see cref="CoreVersionLow"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = CoreVersionLow.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="CoreVersionLow"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(CoreVersionLow.Address, MessageType).Select(CoreVersionLow.GetTimestampedPayload);
+            return CoreVersionLow.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the major version of the Harp core implemented by the device.
+    /// Represents a register that specifies the major version of the Harp core implemented by the device.
     /// </summary>
     [Description("Specifies the major version of the Harp core implemented by the device.")]
-    public partial class FirmwareVersionHigh : HarpCombinator
+    public partial class FirmwareVersionHigh
     {
         /// <summary>
         /// Represents the address of the <see cref="FirmwareVersionHigh"/> register. This field is constant.
@@ -952,14 +628,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="FirmwareVersionHigh"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FirmwareVersionHigh"/> class.
-        /// </summary>
-        public FirmwareVersionHigh()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="FirmwareVersionHigh"/> register messages.
@@ -1010,83 +678,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="FirmwareVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="FirmwareVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="FirmwareVersionHigh"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="FirmwareVersionHigh"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="FirmwareVersionHigh"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the FirmwareVersionHigh register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// FirmwareVersionHigh register.
     /// </summary>
+    /// <seealso cref="FirmwareVersionHigh"/>
     [Description("Filters and selects timestamped messages from the FirmwareVersionHigh register.")]
-    public partial class TimestampedFirmwareVersionHigh : HarpCombinator
+    public partial class TimestampedFirmwareVersionHigh
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="FirmwareVersionHigh"/> register.
+        /// Represents the address of the <see cref="FirmwareVersionHigh"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = FirmwareVersionHigh.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="FirmwareVersionHigh"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(FirmwareVersionHigh.Address, MessageType).Select(FirmwareVersionHigh.GetTimestampedPayload);
+            return FirmwareVersionHigh.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the minor version of the Harp core implemented by the device.
+    /// Represents a register that specifies the minor version of the Harp core implemented by the device.
     /// </summary>
     [Description("Specifies the minor version of the Harp core implemented by the device.")]
-    public partial class FirmwareVersionLow : HarpCombinator
+    public partial class FirmwareVersionLow
     {
         /// <summary>
         /// Represents the address of the <see cref="FirmwareVersionLow"/> register. This field is constant.
@@ -1102,14 +724,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="FirmwareVersionLow"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FirmwareVersionLow"/> class.
-        /// </summary>
-        public FirmwareVersionLow()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="FirmwareVersionLow"/> register messages.
@@ -1160,83 +774,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="FirmwareVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<byte> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="FirmwareVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="byte"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="FirmwareVersionLow"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<byte> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="FirmwareVersionLow"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="byte"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="FirmwareVersionLow"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<byte>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the FirmwareVersionLow register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// FirmwareVersionLow register.
     /// </summary>
+    /// <seealso cref="FirmwareVersionLow"/>
     [Description("Filters and selects timestamped messages from the FirmwareVersionLow register.")]
-    public partial class TimestampedFirmwareVersionLow : HarpCombinator
+    public partial class TimestampedFirmwareVersionLow
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="FirmwareVersionLow"/> register.
+        /// Represents the address of the <see cref="FirmwareVersionLow"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="byte"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<byte>> Process(IObservable<HarpMessage> source)
+        public const int Address = FirmwareVersionLow.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="FirmwareVersionLow"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
         {
-            return source.Where(FirmwareVersionLow.Address, MessageType).Select(FirmwareVersionLow.GetTimestampedPayload);
+            return FirmwareVersionLow.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that stores the integral part of the system timestamp, in seconds.
+    /// Represents a register that stores the integral part of the system timestamp, in seconds.
     /// </summary>
     [Description("Stores the integral part of the system timestamp, in seconds.")]
-    public partial class TimestampSeconds : HarpCombinator
+    public partial class TimestampSeconds
     {
         /// <summary>
         /// Represents the address of the <see cref="TimestampSeconds"/> register. This field is constant.
@@ -1252,14 +820,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="TimestampSeconds"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimestampSeconds"/> class.
-        /// </summary>
-        public TimestampSeconds()
-        {
-            MessageType = MessageType.Event;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="TimestampSeconds"/> register messages.
@@ -1310,83 +870,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromUInt32(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="TimestampSeconds"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="uint"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<uint> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="TimestampSeconds"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="uint"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="TimestampSeconds"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<uint> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="TimestampSeconds"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="uint"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="TimestampSeconds"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<uint>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the TimestampSeconds register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// TimestampSeconds register.
     /// </summary>
+    /// <seealso cref="TimestampSeconds"/>
     [Description("Filters and selects timestamped messages from the TimestampSeconds register.")]
-    public partial class TimestampedTimestampSeconds : HarpCombinator
+    public partial class TimestampedTimestampSeconds
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="TimestampSeconds"/> register.
+        /// Represents the address of the <see cref="TimestampSeconds"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="uint"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<uint>> Process(IObservable<HarpMessage> source)
+        public const int Address = TimestampSeconds.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="TimestampSeconds"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<uint> GetPayload(HarpMessage message)
         {
-            return source.Where(TimestampSeconds.Address, MessageType).Select(TimestampSeconds.GetTimestampedPayload);
+            return TimestampSeconds.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that stores the fractional part of the system timestamp, in microseconds.
+    /// Represents a register that stores the fractional part of the system timestamp, in microseconds.
     /// </summary>
     [Description("Stores the fractional part of the system timestamp, in microseconds.")]
-    public partial class TimestampMicroseconds : HarpCombinator
+    public partial class TimestampMicroseconds
     {
         /// <summary>
         /// Represents the address of the <see cref="TimestampMicroseconds"/> register. This field is constant.
@@ -1402,14 +916,6 @@ namespace Bonsai.Harp
         /// Represents the length of the <see cref="TimestampMicroseconds"/> register. This field is constant.
         /// </summary>
         public const int RegisterLength = 1;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimestampMicroseconds"/> class.
-        /// </summary>
-        public TimestampMicroseconds()
-        {
-            MessageType = MessageType.Read;
-        }
 
         /// <summary>
         /// Returns the payload data for <see cref="TimestampMicroseconds"/> register messages.
@@ -1460,83 +966,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="TimestampMicroseconds"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="TimestampMicroseconds"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="TimestampMicroseconds"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="TimestampMicroseconds"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="TimestampMicroseconds"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the TimestampMicroseconds register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// TimestampMicroseconds register.
     /// </summary>
+    /// <seealso cref="TimestampMicroseconds"/>
     [Description("Filters and selects timestamped messages from the TimestampMicroseconds register.")]
-    public partial class TimestampedTimestampMicroseconds : HarpCombinator
+    public partial class TimestampedTimestampMicroseconds
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="TimestampMicroseconds"/> register.
+        /// Represents the address of the <see cref="TimestampMicroseconds"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = TimestampMicroseconds.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="TimestampMicroseconds"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(TimestampMicroseconds.Address, MessageType).Select(TimestampMicroseconds.GetTimestampedPayload);
+            return TimestampMicroseconds.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that stores the configuration mode of the device.
+    /// Represents a register that stores the configuration mode of the device.
     /// </summary>
     [Description("Stores the configuration mode of the device.")]
-    public partial class OperationControl : HarpCombinator
+    public partial class OperationControl
     {
         /// <summary>
         /// Represents the address of the <see cref="OperationControl"/> register. This field is constant.
@@ -1627,83 +1087,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, FormatPayload(value));
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="OperationControl"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="OperationControlPayload"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<OperationControlPayload> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="OperationControl"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="OperationControlPayload"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="OperationControl"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<OperationControlPayload> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="OperationControl"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="OperationControlPayload"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="OperationControl"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<OperationControlPayload>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the OperationControl register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// OperationControl register.
     /// </summary>
+    /// <seealso cref="OperationControl"/>
     [Description("Filters and selects timestamped messages from the OperationControl register.")]
-    public partial class TimestampedOperationControl : HarpCombinator
+    public partial class TimestampedOperationControl
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="OperationControl"/> register.
+        /// Represents the address of the <see cref="OperationControl"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="OperationControlPayload"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<OperationControlPayload>> Process(IObservable<HarpMessage> source)
+        public const int Address = OperationControl.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="OperationControl"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<OperationControlPayload> GetPayload(HarpMessage message)
         {
-            return source.Where(OperationControl.Address, MessageType).Select(OperationControl.GetTimestampedPayload);
+            return OperationControl.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that resets the device and saves non-volatile registers.
+    /// Represents a register that resets the device and saves non-volatile registers.
     /// </summary>
     [Description("Resets the device and saves non-volatile registers.")]
-    public partial class ResetDevice : HarpCombinator
+    public partial class ResetDevice
     {
         /// <summary>
         /// Represents the address of the <see cref="ResetDevice"/> register. This field is constant.
@@ -1770,83 +1184,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="ResetDevice"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ResetFlags"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ResetFlags> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="ResetDevice"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ResetFlags"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="ResetDevice"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ResetFlags> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="ResetDevice"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ResetFlags"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="ResetDevice"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ResetFlags>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the ResetDevice register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// ResetDevice register.
     /// </summary>
+    /// <seealso cref="ResetDevice"/>
     [Description("Filters and selects timestamped messages from the ResetDevice register.")]
-    public partial class TimestampedResetDevice : HarpCombinator
+    public partial class TimestampedResetDevice
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="ResetDevice"/> register.
+        /// Represents the address of the <see cref="ResetDevice"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ResetFlags"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ResetFlags>> Process(IObservable<HarpMessage> source)
+        public const int Address = ResetDevice.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="ResetDevice"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ResetFlags> GetPayload(HarpMessage message)
         {
-            return source.Where(ResetDevice.Address, MessageType).Select(ResetDevice.GetTimestampedPayload);
+            return ResetDevice.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that stores the user-specified device name.
+    /// Represents a register that stores the user-specified device name.
     /// </summary>
     [Description("Stores the user-specified device name.")]
-    public partial class DeviceName : HarpCombinator
+    public partial class DeviceName
     {
         /// <summary>
         /// Represents the address of the <see cref="DeviceName"/> register. This field is constant.
@@ -1926,83 +1294,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromPayload(Address, timestamp, messageType, PayloadType.U8, FormatPayload(value));
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="DeviceName"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="string"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<string> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="DeviceName"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="string"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="DeviceName"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<string> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="DeviceName"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="string"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="DeviceName"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<string>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the DeviceName register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// DeviceName register.
     /// </summary>
+    /// <seealso cref="DeviceName"/>
     [Description("Filters and selects timestamped messages from the DeviceName register.")]
-    public partial class TimestampedDeviceName : HarpCombinator
+    public partial class TimestampedDeviceName
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="DeviceName"/> register.
+        /// Represents the address of the <see cref="DeviceName"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="string"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<string>> Process(IObservable<HarpMessage> source)
+        public const int Address = DeviceName.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="DeviceName"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<string> GetPayload(HarpMessage message)
         {
-            return source.Where(DeviceName.Address, MessageType).Select(DeviceName.GetTimestampedPayload);
+            return DeviceName.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the unique serial number of the device.
+    /// Represents a register that specifies the unique serial number of the device.
     /// </summary>
     [Description("Specifies the unique serial number of the device.")]
-    public partial class SerialNumber : HarpCombinator
+    public partial class SerialNumber
     {
         /// <summary>
         /// Represents the address of the <see cref="SerialNumber"/> register. This field is constant.
@@ -2068,83 +1390,37 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
         }
-
-        /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="SerialNumber"/> register.
-        /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ushort> Process(IObservable<HarpMessage> source)
-        {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="SerialNumber"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ushort"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="SerialNumber"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ushort> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="SerialNumber"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ushort"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="SerialNumber"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ushort>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
-        }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the SerialNumber register.
+    /// Provides methods for manipulating timestamped messages from the
+    /// SerialNumber register.
     /// </summary>
+    /// <seealso cref="SerialNumber"/>
     [Description("Filters and selects timestamped messages from the SerialNumber register.")]
-    public partial class TimestampedSerialNumber : HarpCombinator
+    public partial class TimestampedSerialNumber
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="SerialNumber"/> register.
+        /// Represents the address of the <see cref="SerialNumber"/> register. This field is constant.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="ushort"/> objects
-        /// representing the register payload.
-        /// </returns>
-        public IObservable<Timestamped<ushort>> Process(IObservable<HarpMessage> source)
+        public const int Address = SerialNumber.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="SerialNumber"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
         {
-            return source.Where(SerialNumber.Address, MessageType).Select(SerialNumber.GetTimestampedPayload);
+            return SerialNumber.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that specifies the configuration for the device synchronization clock.
+    /// Represents a register that specifies the configuration for the device synchronization clock.
     /// </summary>
     [Description("Specifies the configuration for the device synchronization clock.")]
-    public partial class ClockConfiguration : HarpCombinator
+    public partial class ClockConfiguration
     {
         /// <summary>
         /// Represents the address of the <see cref="ClockConfiguration"/> register. This field is constant.
@@ -2211,75 +1487,413 @@ namespace Bonsai.Harp
         {
             return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// ClockConfiguration register.
+    /// </summary>
+    /// <seealso cref="ClockConfiguration"/>
+    [Description("Filters and selects timestamped messages from the ClockConfiguration register.")]
+    public partial class TimestampedClockConfiguration
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="ClockConfiguration"/> register. This field is constant.
+        /// </summary>
+        public const int Address = ClockConfiguration.Address;
 
         /// <summary>
-        /// Filters and selects an observable sequence of messages from the
-        /// <see cref="ClockConfiguration"/> register.
+        /// Returns timestamped payload data for <see cref="ClockConfiguration"/> register messages.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
-        /// <returns>
-        /// A sequence of <see cref="ClockConfigurationFlags"/> objects representing the
-        /// message payload.
-        /// </returns>
-        public IObservable<ClockConfigurationFlags> Process(IObservable<HarpMessage> source)
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ClockConfigurationFlags> GetPayload(HarpMessage message)
         {
-            return source.Where(Address, MessageType).Select(GetPayload);
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into Harp messages
-        /// for the <see cref="ClockConfiguration"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of <see cref="ClockConfigurationFlags"/> objects representing the
-        /// message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects formatted for the
-        /// <see cref="ClockConfiguration"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<ClockConfigurationFlags> source)
-        {
-            return source.Select(value => FromPayload(MessageType, value));
-        }
-
-        /// <summary>
-        /// Formats an observable sequence of values into timestamped Harp messages
-        /// for the <see cref="ClockConfiguration"/> register.
-        /// </summary>
-        /// <param name="source">
-        /// A sequence of timestamped <see cref="ClockConfigurationFlags"/> objects representing
-        /// the message payload.
-        /// </param>
-        /// <returns>
-        /// A sequence of timestamped <see cref="HarpMessage"/> objects formatted for
-        /// the <see cref="ClockConfiguration"/> register.
-        /// </returns>
-        public IObservable<HarpMessage> Process(IObservable<Timestamped<ClockConfigurationFlags>> source)
-        {
-            return source.Select(payload => FromPayload(payload.Seconds, MessageType, payload.Value));
+            return ClockConfiguration.GetTimestampedPayload(message);
         }
     }
 
     /// <summary>
-    /// Represents an operator that filters and selects a sequence of timestamped messages
-    /// from the ClockConfiguration register.
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the identity class of the device.
     /// </summary>
-    [Description("Filters and selects timestamped messages from the ClockConfiguration register.")]
-    public partial class TimestampedClockConfiguration : HarpCombinator
+    [DisplayName("WhoAmIPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the identity class of the device.")]
+    public partial class CreateWhoAmIPayload : HarpCombinator
     {
         /// <summary>
-        /// Filters and selects an observable sequence of timestamped messages from
-        /// the <see cref="ClockConfiguration"/> register.
+        /// Gets or sets the value that specifies the identity class of the device.
         /// </summary>
-        /// <param name="source">The sequence of Harp device messages.</param>
+        [Description("The value that specifies the identity class of the device.")]
+        public int Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the identity class of the device.
+        /// </summary>
         /// <returns>
-        /// A sequence of timestamped <see cref="ClockConfigurationFlags"/> objects
-        /// representing the register payload.
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
         /// </returns>
-        public IObservable<Timestamped<ClockConfigurationFlags>> Process(IObservable<HarpMessage> source)
+        public IObservable<HarpMessage> Process()
         {
-            return source.Where(ClockConfiguration.Address, MessageType).Select(ClockConfiguration.GetTimestampedPayload);
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the identity class of the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => WhoAmI.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the major hardware version of the device.
+    /// </summary>
+    [DisplayName("HardwareVersionHighPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the major hardware version of the device.")]
+    public partial class CreateHardwareVersionHighPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the major hardware version of the device.
+        /// </summary>
+        [Description("The value that specifies the major hardware version of the device.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the major hardware version of the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the major hardware version of the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => HardwareVersionHigh.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the minor hardware version of the device.
+    /// </summary>
+    [DisplayName("HardwareVersionLowPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the minor hardware version of the device.")]
+    public partial class CreateHardwareVersionLowPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the minor hardware version of the device.
+        /// </summary>
+        [Description("The value that specifies the minor hardware version of the device.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the minor hardware version of the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the minor hardware version of the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => HardwareVersionLow.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the version of the assembled components in the device.
+    /// </summary>
+    [DisplayName("AssemblyVersionPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the version of the assembled components in the device.")]
+    public partial class CreateAssemblyVersionPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the version of the assembled components in the device.
+        /// </summary>
+        [Description("The value that specifies the version of the assembled components in the device.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the version of the assembled components in the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the version of the assembled components in the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => AssemblyVersion.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the major version of the Harp core implemented by the device.
+    /// </summary>
+    [DisplayName("CoreVersionHighPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the major version of the Harp core implemented by the device.")]
+    public partial class CreateCoreVersionHighPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the major version of the Harp core implemented by the device.
+        /// </summary>
+        [Description("The value that specifies the major version of the Harp core implemented by the device.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the major version of the Harp core implemented by the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the major version of the Harp core implemented by the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => CoreVersionHigh.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the minor version of the Harp core implemented by the device.
+    /// </summary>
+    [DisplayName("CoreVersionLowPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the minor version of the Harp core implemented by the device.")]
+    public partial class CreateCoreVersionLowPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the minor version of the Harp core implemented by the device.
+        /// </summary>
+        [Description("The value that specifies the minor version of the Harp core implemented by the device.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the minor version of the Harp core implemented by the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the minor version of the Harp core implemented by the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => CoreVersionLow.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the major version of the Harp core implemented by the device.
+    /// </summary>
+    [DisplayName("FirmwareVersionHighPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the major version of the Harp core implemented by the device.")]
+    public partial class CreateFirmwareVersionHighPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the major version of the Harp core implemented by the device.
+        /// </summary>
+        [Description("The value that specifies the major version of the Harp core implemented by the device.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the major version of the Harp core implemented by the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the major version of the Harp core implemented by the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => FirmwareVersionHigh.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the minor version of the Harp core implemented by the device.
+    /// </summary>
+    [DisplayName("FirmwareVersionLowPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the minor version of the Harp core implemented by the device.")]
+    public partial class CreateFirmwareVersionLowPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the minor version of the Harp core implemented by the device.
+        /// </summary>
+        [Description("The value that specifies the minor version of the Harp core implemented by the device.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the minor version of the Harp core implemented by the device.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the minor version of the Harp core implemented by the device.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => FirmwareVersionLow.FromPayload(MessageType, Value));
         }
     }
 
@@ -2328,6 +1942,54 @@ namespace Bonsai.Harp
         public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
         {
             return source.Select(_ => TimestampSeconds.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that stores the fractional part of the system timestamp, in microseconds.
+    /// </summary>
+    [DisplayName("TimestampMicrosecondsPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that stores the fractional part of the system timestamp, in microseconds.")]
+    public partial class CreateTimestampMicrosecondsPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that stores the fractional part of the system timestamp, in microseconds.
+        /// </summary>
+        [Description("The value that stores the fractional part of the system timestamp, in microseconds.")]
+        public ushort Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that stores the fractional part of the system timestamp, in microseconds.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that stores the fractional part of the system timestamp, in microseconds.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => TimestampMicroseconds.FromPayload(MessageType, Value));
         }
     }
 

--- a/Bonsai.Harp/Device.Generated.cs
+++ b/Bonsai.Harp/Device.Generated.cs
@@ -9,25 +9,25 @@ namespace Bonsai.Harp
     public partial class Device
     {
         /// <summary>
-        /// Gets a read-only mapping from address to register name.
+        /// Gets a read-only mapping from address to register type.
         /// </summary>
-        public static IReadOnlyDictionary<int, string> RegisterMap { get; } = new Dictionary<int, string>
+        public static IReadOnlyDictionary<int, Type> RegisterMap { get; } = new Dictionary<int, Type>
         {
-            { 0, "WhoAmI" },
-            { 1, "HardwareVersionHigh" },
-            { 2, "HardwareVersionLow" },
-            { 3, "AssemblyVersion" },
-            { 4, "CoreVersionHigh" },
-            { 5, "CoreVersionLow" },
-            { 6, "FirmwareVersionHigh" },
-            { 7, "FirmwareVersionLow" },
-            { 8, "TimestampSeconds" },
-            { 9, "TimestampMicroseconds" },
-            { 10, "OperationControl" },
-            { 11, "ResetDevice" },
-            { 12, "DeviceName" },
-            { 13, "SerialNumber" },
-            { 14, "ClockConfiguration" }
+            { 0, typeof(WhoAmI) },
+            { 1, typeof(HardwareVersionHigh) },
+            { 2, typeof(HardwareVersionLow) },
+            { 3, typeof(AssemblyVersion) },
+            { 4, typeof(CoreVersionHigh) },
+            { 5, typeof(CoreVersionLow) },
+            { 6, typeof(FirmwareVersionHigh) },
+            { 7, typeof(FirmwareVersionLow) },
+            { 8, typeof(TimestampSeconds) },
+            { 9, typeof(TimestampMicroseconds) },
+            { 10, typeof(OperationControl) },
+            { 11, typeof(ResetDevice) },
+            { 12, typeof(DeviceName) },
+            { 13, typeof(SerialNumber) },
+            { 14, typeof(ClockConfiguration) }
         };
     }
 

--- a/Bonsai.Harp/EventBuilder.cs
+++ b/Bonsai.Harp/EventBuilder.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq.Expressions;
+using Bonsai.Expressions;
 
 namespace Bonsai.Harp
 {
@@ -11,6 +14,8 @@ namespace Bonsai.Harp
     [DefaultProperty(nameof(Event))]
     public abstract class EventBuilder : HarpCombinatorBuilder, INamedElement
     {
+        readonly CombinatorBuilder builder = new CombinatorBuilder();
+
         string INamedElement.Name => $"{RemoveSuffix(GetType().Name, nameof(Event))}.{GetElementDisplayName(Event)}";
 
         /// <summary>
@@ -26,8 +31,17 @@ namespace Bonsai.Harp
         [TypeConverter(typeof(CombinatorTypeConverter))]
         public object Event
         {
-            get { return Combinator; }
-            set { Combinator = value; }
+            get { return Operator; }
+            set { builder.Combinator = Operator = value; }
+        }
+
+        /// <inheritdoc/>
+        public override Range<int> ArgumentRange => builder.ArgumentRange;
+
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return builder.Build(arguments);
         }
     }
 }

--- a/Bonsai.Harp/FilterMessage.cs
+++ b/Bonsai.Harp/FilterMessage.cs
@@ -45,7 +45,6 @@ namespace Bonsai.Harp
     [XmlInclude(typeof(SerialNumber))]
     [XmlInclude(typeof(ClockConfiguration))]
     [Description("Filters the sequence for Harp messages that match the specified register and message type.")]
-    [WorkflowElementIcon(typeof(ElementCategory), "Reactive.Condition")]
     public class FilterMessage : FilterMessageBuilder, INamedElement
     {
         /// <summary>

--- a/Bonsai.Harp/FilterMessage.cs
+++ b/Bonsai.Harp/FilterMessage.cs
@@ -143,9 +143,9 @@ namespace Bonsai.Harp
             var address = Address;
             var messageType = MessageType;
             if (address == null && messageType == null) return source;
-            if (address == null) return source.Where(input => input.MessageType == messageType);
-            if (messageType == null) return source.Where(input => input.Address == address);
-            return source.Where(input => input.Address == address && input.MessageType == messageType);
+            if (address == null) return source.Where(messageType.Value);
+            if (messageType == null) return source.Where(address.Value);
+            return source.Where(address.Value, messageType.Value);
         }
     }
 }

--- a/Bonsai.Harp/FilterMessageBuilder.cs
+++ b/Bonsai.Harp/FilterMessageBuilder.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Xml.Serialization;
-using Bonsai.Expressions;
 
 namespace Bonsai.Harp
 {
@@ -15,6 +14,7 @@ namespace Bonsai.Harp
     [DefaultProperty(nameof(Register))]
     [XmlType(Namespace = Constants.XmlNamespace)]
     [WorkflowElementCategory(ElementCategory.Combinator)]
+    [WorkflowElementIcon(typeof(ElementCategory), "Reactive.Condition")]
     public abstract class FilterMessageBuilder : HarpCombinatorBuilder
     {
         static readonly Range<int> argumentRange = Range.Create(lowerBound: 1, upperBound: 1);

--- a/Bonsai.Harp/FilterMessageBuilder.cs
+++ b/Bonsai.Harp/FilterMessageBuilder.cs
@@ -66,22 +66,10 @@ namespace Bonsai.Harp
             }
 
             var source = arguments.First();
-            var combinator = Expression.Constant(this, typeof(FilterMessageBuilder));
-            if (register is ExpressionBuilder builder)
-            {
-                return Expression.Call(combinator, nameof(Filter), null, source);
-            }
-
             var registerType = register.GetType();
+            var combinator = Expression.Constant(this, typeof(FilterMessageBuilder));
             var address = Expression.Field(null, registerType, nameof(HarpMessage.Address));
             return Expression.Call(combinator, nameof(Filter), null, source, address);
-        }
-
-        IObservable<HarpMessage> Filter(IObservable<HarpMessage> source)
-        {
-            var messageType = MessageType;
-            if (messageType == null) return source;
-            else return source.Where(messageType.Value);
         }
 
         IObservable<HarpMessage> Filter(IObservable<HarpMessage> source, int address)

--- a/Bonsai.Harp/FilterMessageBuilder.cs
+++ b/Bonsai.Harp/FilterMessageBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Xml.Serialization;
@@ -11,32 +10,40 @@ namespace Bonsai.Harp
 {
     /// <summary>
     /// Provides the abstract base class for polymorphic operators used to filter
-    /// a sequence of Harp messages for elements that match the specified register
-    /// and message type.
+    /// a sequence for Harp messages matching the specified register and message type.
     /// </summary>
     [DefaultProperty(nameof(Register))]
     [XmlType(Namespace = Constants.XmlNamespace)]
     [WorkflowElementCategory(ElementCategory.Combinator)]
-    public abstract class FilterMessageBuilder : SingleArgumentExpressionBuilder, ICustomTypeDescriptor
+    public abstract class FilterMessageBuilder : HarpCombinatorBuilder
     {
+        static readonly Range<int> argumentRange = Range.Create(lowerBound: 1, upperBound: 1);
+
+        /// <inheritdoc/>
+        public override Range<int> ArgumentRange => argumentRange;
+
         /// <summary>
-        /// Gets or sets the register used to filter Harp device messages.
+        /// Gets or sets a value specifying the expected message type. This parameter is optional.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("Specifies the expected message type. This parameter is optional.")]
+        public MessageType? MessageType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the operator used to filter and select messages from
+        /// specific device registers.
         /// </summary>
         [DesignOnly(true)]
         [Externalizable(false)]
         [RefreshProperties(RefreshProperties.All)]
         [Category(nameof(CategoryAttribute.Design))]
-        [TypeConverter(typeof(CombinatorTypeMappingConverter))]
-        [Description("The register used to filter Harp device messages.")]
-        public TypeMapping Register { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying the type of Harp device message to filter.
-        /// This parameter is optional.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Design))]
-        [Description("Specifies the type of Harp device message to filter. This parameter is optional.")]
-        public MessageType? MessageType { get; set; }
+        [Description("The operator used to filter and select messages from specific device registers.")]
+        [TypeConverter(typeof(CombinatorTypeConverter))]
+        public object Register
+        {
+            get { return Operator; }
+            set { Operator = value; }
+        }
 
         /// <summary>
         /// Returns a value indicating whether the <see cref="MessageType"/> property
@@ -53,145 +60,35 @@ namespace Bonsai.Harp
         public override Expression Build(IEnumerable<Expression> arguments)
         {
             var register = Register;
-            var messageType = MessageType;
-            var source = arguments.First();
             if (register == null)
             {
-                throw new InvalidOperationException("The target register type cannot be null.");
+                throw new InvalidOperationException("A valid register operator object must be specified.");
             }
 
-            var registerType = register.GetType().GenericTypeArguments[0];
-            var registerAddress = Expression.Field(null, registerType, nameof(HarpMessage.Address));
-            var filterArguments = messageType.HasValue
-                ? new[] { source, registerAddress, Expression.Constant(messageType.Value) }
-                : new[] { source, registerAddress };
-            return Expression.Call(
-                typeof(ObservableExtensions),
-                nameof(ObservableExtensions.Where),
-                typeArguments: null,
-                filterArguments);
-        }
-
-        class CombinatorTypeMappingConverter : CombinatorTypeConverter
-        {
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            var source = arguments.First();
+            var combinator = Expression.Constant(this, typeof(FilterMessageBuilder));
+            if (register is ExpressionBuilder builder)
             {
-                if (value is string typeName)
-                {
-                    var includeType = GetInstanceTypes(context).FirstOrDefault(
-                        type => string.Equals(type.GenericTypeArguments[0].Name, typeName, StringComparison.OrdinalIgnoreCase));
-                    if (includeType != null) return Activator.CreateInstance(includeType);
-                }
-
-                return null;
+                return Expression.Call(combinator, nameof(Filter), null, source);
             }
 
-            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-            {
-                if (destinationType == typeof(string) && value is TypeMapping valueType)
-                {
-                    return valueType.GetType().GenericTypeArguments[0].Name;
-                }
-
-                return null;
-            }
-
-            public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
-            {
-                var includeTypes = GetInstanceTypes(context).Select(Activator.CreateInstance).ToArray();
-                return new StandardValuesCollection(includeTypes);
-            }
+            var registerType = register.GetType();
+            var address = Expression.Field(null, registerType, nameof(HarpMessage.Address));
+            return Expression.Call(combinator, nameof(Filter), null, source, address);
         }
 
-        #region ICustomTypeDescriptor Members
-
-        AttributeCollection ICustomTypeDescriptor.GetAttributes()
+        IObservable<HarpMessage> Filter(IObservable<HarpMessage> source)
         {
-            var attributes = TypeDescriptor.GetAttributes(GetType());
-            var defaultProperty = TypeDescriptor.GetDefaultProperty(GetType());
-            if (defaultProperty != null)
-            {
-                var instance = defaultProperty.GetValue(this);
-                if (instance is TypeMapping)
-                {
-                    var mappingAttributes = TypeDescriptor.GetAttributes(instance.GetType().GenericTypeArguments[0]);
-                    if (mappingAttributes[typeof(DescriptionAttribute)] is DescriptionAttribute description)
-                    {
-                        return AttributeCollection.FromExisting(attributes, description);
-                    }
-                }
-            }
-
-            return attributes;
+            var messageType = MessageType;
+            if (messageType == null) return source;
+            else return source.Where(messageType.Value);
         }
 
-        string ICustomTypeDescriptor.GetClassName()
+        IObservable<HarpMessage> Filter(IObservable<HarpMessage> source, int address)
         {
-            return TypeDescriptor.GetClassName(GetType());
+            var messageType = MessageType;
+            if (messageType == null) return source.Where(address);
+            else return source.Where(address, messageType.Value);
         }
-
-        string ICustomTypeDescriptor.GetComponentName()
-        {
-            return null;
-        }
-
-        TypeConverter ICustomTypeDescriptor.GetConverter()
-        {
-            return TypeDescriptor.GetConverter(GetType());
-        }
-
-        EventDescriptor ICustomTypeDescriptor.GetDefaultEvent()
-        {
-            return null;
-        }
-
-        PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty()
-        {
-            return TypeDescriptor.GetDefaultProperty(GetType());
-        }
-
-        object ICustomTypeDescriptor.GetEditor(Type editorBaseType)
-        {
-            return TypeDescriptor.GetEditor(GetType(), editorBaseType);
-        }
-
-        EventDescriptorCollection ICustomTypeDescriptor.GetEvents()
-        {
-            return EventDescriptorCollection.Empty;
-        }
-
-        EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes)
-        {
-            return EventDescriptorCollection.Empty;
-        }
-
-        PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties()
-        {
-            return ((ICustomTypeDescriptor)this).GetProperties(new Attribute[0]);
-        }
-
-        PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[] attributes)
-        {
-            var properties = TypeDescriptor.GetProperties(GetType(), attributes);
-            var defaultProperty = TypeDescriptor.GetDefaultProperty(GetType());
-            if (defaultProperty != null)
-            {
-                var instance = defaultProperty.GetValue(this);
-                var includeAddress = instance is TypeMapping<FilterMessageAddress>;
-                return new PropertyDescriptorCollection(properties
-                    .Cast<PropertyDescriptor>()
-                    .Where(property => includeAddress || property.Name != nameof(FilterMessageAddress.Address))
-                    .ToArray());
-            }
-
-            return properties;
-        }
-
-        object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor pd)
-        {
-            return this;
-        }
-
-        #endregion
     }
 }

--- a/Bonsai.Harp/Format.cs
+++ b/Bonsai.Harp/Format.cs
@@ -7,8 +7,8 @@ using System.Xml.Serialization;
 namespace Bonsai.Harp
 {
     /// <summary>
-    /// Represents an operator which formats a sequence of values as specific
-    /// Harp device register messages.
+    /// Represents an operator which formats a sequence of values as
+    /// standard Harp device messages.
     /// </summary>
     /// <seealso cref="FormatMessagePayload"/>
     /// <seealso cref="WhoAmI"/>
@@ -42,7 +42,7 @@ namespace Bonsai.Harp
     [XmlInclude(typeof(DeviceName))]
     [XmlInclude(typeof(SerialNumber))]
     [XmlInclude(typeof(ClockConfiguration))]
-    [Description("Formats a sequence of values as specific Device register messages.")]
+    [Description("Formats a sequence of values as standard Harp device messages.")]
     public class Format : FormatBuilder, INamedElement
     {
         /// <summary>
@@ -57,15 +57,25 @@ namespace Bonsai.Harp
             ? default
             : $"Device.{GetElementDisplayName(Register)}";
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public MessageType MessageType
+        /// <summary>
+        /// Gets or sets a value specifying the type of the formatted message.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("Specifies the type of the formatted message.")]
+        public new MessageType MessageType
         {
-            get { return Register is FormatMessagePayload formatMessage ? formatMessage.MessageType : default; }
-            set { if (Register is FormatMessagePayload formatMessage) formatMessage.MessageType = value; }
+            get { return base.MessageType; }
+            set
+            {
+                base.MessageType = value;
+                if (Register is FormatMessagePayload formatMessage)
+                {
+                    formatMessage.MessageType = value;
+                }
+            }
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int Address
@@ -84,10 +94,6 @@ namespace Bonsai.Harp
 
         [Obsolete]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeMessageType() => false;
-
-        [Obsolete]
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool ShouldSerializeAddress() => false;
 
         [Obsolete]
@@ -97,43 +103,36 @@ namespace Bonsai.Harp
     }
 
     /// <summary>
-    /// Represents an operator which formats input data as a Harp message payload.
+    /// Represents an operator which formats a sequence of values as Harp messages
+    /// with the specified address and payload type.
     /// </summary>
     [DesignTimeVisible(false)]
-    [Description("Formats input data as a Harp message.")]
+    [Description("Formats a sequence of values as Harp messages with the specified address and payload type.")]
     public class FormatMessagePayload : SelectBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FormatMessagePayload"/> class.
+        /// Gets or sets the type of the formatted message.
         /// </summary>
-        public FormatMessagePayload()
-        {
-            Address = 32;
-            MessageType = MessageType.Write;
-            PayloadType = PayloadType.U8;
-        }
-
-        /// <summary>
-        /// Gets or sets the type of the Harp message.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Design))]
-        [Description("The type of the Harp message.")]
-        public MessageType MessageType { get; set; }
+        [XmlIgnore]
+        [Browsable(false)]
+        [Description("Specifies the type of the formatted message.")]
+        public MessageType MessageType { get; set; } = MessageType.Write;
 
         /// <summary>
         /// Gets or sets the address of the register to which the Harp message refers to.
         /// </summary>
         [Description("The address of the register to which the Harp message refers to.")]
-        public int Address { get; set; }
+        public int Address { get; set; } = 32;
 
         /// <summary>
         /// Gets or sets the type of data to include in the message payload.
         /// </summary>
         [Description("The type of data to include in the message payload.")]
-        public PayloadType PayloadType { get; set; }
+        public PayloadType PayloadType { get; set; } = PayloadType.U8;
 
         /// <summary>
-        /// Returns the expression that specifies how a valid Harp message is created from the input data.
+        /// Returns the expression that specifies how a valid Harp message is created
+        /// from the input data.
         /// </summary>
         /// <param name="expression">The input parameter to the selector.</param>
         /// <returns>

--- a/Bonsai.Harp/FormatBuilder.cs
+++ b/Bonsai.Harp/FormatBuilder.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reactive.Linq;
 using System.Xml.Serialization;
+using Bonsai.Expressions;
 
 namespace Bonsai.Harp
 {
@@ -21,6 +24,13 @@ namespace Bonsai.Harp
         public override Range<int> ArgumentRange => argumentRange;
 
         /// <summary>
+        /// Gets or sets a value specifying the type of the formatted message.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("Specifies the type of the formatted message.")]
+        public MessageType MessageType { get; set; } = MessageType.Write;
+
+        /// <summary>
         /// Gets or sets the operator used to format the source data into specific
         /// Harp device register messages.
         /// </summary>
@@ -32,15 +42,86 @@ namespace Bonsai.Harp
         [TypeConverter(typeof(CombinatorTypeConverter))]
         public object Register
         {
-            get { return Combinator; }
-            set { Combinator = value; }
+            get { return Operator; }
+            set { Operator = value; }
         }
 
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)
         {
-            return base.Build(arguments
-                .Where(expression => expression.Type.GenericTypeArguments[0] != typeof(HarpMessage)));
+            var register = Register;
+            if (register == null)
+            {
+                throw new InvalidOperationException("A valid register operator object must be specified.");
+            }
+
+            if (register is ExpressionBuilder builder)
+            {
+                return builder.Build(arguments);
+            }
+
+            var source = arguments.First();
+            var registerType = register.GetType();
+            var payloadType = source.Type.GenericTypeArguments[0];
+
+            ParameterExpression[] selectorParameters;
+            var messageType = Expression.Parameter(typeof(MessageType), "messageType");
+            if (payloadType.IsGenericType && payloadType.GetGenericTypeDefinition() == typeof(Timestamped<>))
+            {
+                payloadType = payloadType.GenericTypeArguments[0];
+                var timestamp = Expression.Parameter(typeof(double), "timestamp");
+                var value = Expression.Parameter(payloadType, "value");
+                selectorParameters = new[] { timestamp, messageType, value };
+            }
+            else
+            {
+                var value = Expression.Parameter(payloadType, "value");
+                selectorParameters = new[] { messageType, value };
+            }
+
+            var selectorMethod = registerType.GetMethods().FirstOrDefault(m =>
+                m.Name == nameof(HarpMessage.FromPayload) &&
+                m.GetParameters().Length == selectorParameters.Length);
+            if (selectorMethod == null)
+            {
+                throw new InvalidOperationException(
+                    $"No compatible method '{nameof(HarpMessage.FromPayload)}' was found for the specified register.");
+            }
+
+            var parameterIndex = 0;
+            var methodParameters = selectorMethod.GetParameters();
+            var selectorArguments = Array.ConvertAll(selectorMethod.GetParameters(), parameter =>
+            {
+                var selectorParameter = selectorParameters[parameterIndex++];
+                return parameter.ParameterType != selectorParameter.Type
+                    ? (Expression)Expression.Convert(selectorParameter, parameter.ParameterType)
+                    : selectorParameter;
+            });
+
+            var combinator = Expression.Constant(this, typeof(FormatBuilder));
+            var selector = Expression.Lambda(
+                Expression.Call(registerType, nameof(HarpMessage.FromPayload), null, selectorArguments),
+                selectorParameters);
+            return Expression.Call(
+                combinator,
+                nameof(Process),
+                new[] { payloadType },
+                source,
+                selector);
+        }
+
+
+
+        IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source, Func<MessageType, TSource, HarpMessage> selector)
+        {
+            var messageType = MessageType;
+            return source.Select(payload => selector(messageType, payload));
+        }
+
+        IObservable<HarpMessage> Process<TSource>(IObservable<Timestamped<TSource>> source, Func<double, MessageType, TSource, HarpMessage> selector)
+        {
+            var messageType = MessageType;
+            return source.Select(payload => selector(payload.Seconds, messageType, payload.Value));
         }
     }
 }

--- a/Bonsai.Harp/Parse.cs
+++ b/Bonsai.Harp/Parse.cs
@@ -180,6 +180,17 @@ namespace Bonsai.Harp
         [Description("Indicates whether the payload is an array.")]
         public bool IsArray { get; set; }
 
+        /// <summary>
+        /// Returns a value indicating whether the <see cref="Address"/> property
+        /// should be serialized.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the <see cref="Address"/> should be serialized;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ShouldSerializeAddress() => Address.HasValue;
+
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)
         {

--- a/Bonsai.Harp/Parse.cs
+++ b/Bonsai.Harp/Parse.cs
@@ -1,16 +1,14 @@
 ﻿using Bonsai.Expressions;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Xml.Serialization;
 
 namespace Bonsai.Harp
 {
     /// <summary>
-    /// Represents an operator which filters and selects specific messages
-    /// reported by the Device device.
+    /// Represents an operator which filters and selects standard Harp
+    /// messages reported by the device.
     /// </summary>
     /// <seealso cref="ParseMessagePayload"/>
     /// <seealso cref="WhoAmI"/>
@@ -59,6 +57,7 @@ namespace Bonsai.Harp
     [XmlInclude(typeof(TimestampedDeviceName))]
     [XmlInclude(typeof(TimestampedSerialNumber))]
     [XmlInclude(typeof(TimestampedClockConfiguration))]
+    [Description("Filters and selects standard Harp messages reported by the device.")]
     public class Parse : ParseBuilder, INamedElement
     {
         /// <summary>
@@ -107,8 +106,6 @@ namespace Bonsai.Harp
     [Description("Extracts the payload data from Harp messages.")]
     public class ParseMessagePayload : SelectBuilder
     {
-        readonly FilterMessageAddress filterMessage = new FilterMessageAddress();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ParseMessagePayload"/> class.
         /// </summary>
@@ -118,25 +115,10 @@ namespace Bonsai.Harp
         }
 
         /// <summary>
-        /// Gets or sets the desired message address. This parameter is optional.
+        /// Gets or sets the expected message address. This parameter is optional.
         /// </summary>
-        [Description("The desired message address. This parameter is optional.")]
-        public int? Address
-        {
-            get => filterMessage.Address;
-            set => filterMessage.Address = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the desired type of the message. This parameter is optional.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Design))]
-        [Description("The desired type of the message. This parameter is optional.")]
-        public MessageType? MessageType
-        {
-            get => filterMessage.MessageType;
-            set => filterMessage.MessageType = value;
-        }
+        [Description("The expected message address. This parameter is optional.")]
+        public int? Address { get; set; }
 
         /// <summary>
         /// Gets or sets the type of payload data to parse.
@@ -149,35 +131,6 @@ namespace Bonsai.Harp
         /// </summary>
         [Description("Indicates whether the payload is an array.")]
         public bool IsArray { get; set; }
-
-        /// <summary>
-        /// Returns a value indicating whether the <see cref="Address"/> property
-        /// should be serialized.
-        /// </summary>
-        /// <returns>
-        /// <see langword="true"/> if the <see cref="Address"/> should be serialized;
-        /// otherwise, <see langword="false"/>.
-        /// </returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeAddress() => Address.HasValue;
-
-        /// <summary>
-        /// Returns a value indicating whether the <see cref="MessageType"/> property
-        /// should be serialized.
-        /// </summary>
-        /// <returns>
-        /// <see langword="true"/> if the <see cref="MessageType"/> should be serialized;
-        /// otherwise, <see langword="false"/>.
-        /// </returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeMessageType() => MessageType.HasValue;
-
-        /// <inheritdoc/>
-        public override Expression Build(IEnumerable<Expression> arguments)
-        {
-            var filter = Expression.Constant(filterMessage);
-            return base.Build(arguments.Select(source => Expression.Call(filter, nameof(FilterMessageAddress.Process), null, source)));
-        }
 
         /// <summary>
         /// Returns the expression that specifies how to extract the payload data from a valid Harp message.

--- a/Bonsai.Harp/ParseBuilder.cs
+++ b/Bonsai.Harp/ParseBuilder.cs
@@ -18,11 +18,6 @@ namespace Bonsai.Harp
         {
             var register = Register;
             var source = base.Build(arguments);
-            if (register is ExpressionBuilder builder)
-            {
-                return builder.Build(new[] { source });
-            }
-
             var registerType = register.GetType();
             var payload = Expression.Parameter(typeof(HarpMessage));
             var payloadSelector = Expression.Lambda(

--- a/Bonsai.Harp/ParseBuilder.cs
+++ b/Bonsai.Harp/ParseBuilder.cs
@@ -2,7 +2,6 @@
 using System.Linq.Expressions;
 using System.Reactive.Linq;
 using System.Xml.Serialization;
-using Bonsai.Expressions;
 
 namespace Bonsai.Harp
 {
@@ -11,6 +10,7 @@ namespace Bonsai.Harp
     /// and select messages from specific registers in a Harp device.
     /// </summary>
     [XmlType(Namespace = Constants.XmlNamespace)]
+    [WorkflowElementIcon(typeof(ElementCategory), "ElementIcon.Daq")]
     public abstract class ParseBuilder : FilterMessageBuilder
     {
         /// <inheritdoc/>


### PR DESCRIPTION
This PR refactors the core Harp message manipulation operators to avoid having custom logic in generated register types. The goal is to improve the library robustness to future redesign, since all that the custom device packages really need to provide is the specific logic for parsing or formatting message payloads.