### PR TITLE
Add specialized operator for logging Harp messages

### DIFF
--- a/Bonsai.Harp/Bonsai.Harp.csproj
+++ b/Bonsai.Harp/Bonsai.Harp.csproj
@@ -12,10 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.7.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.IO.Ports" Version="6.0.0" />
+    <PackageReference Include="Bonsai.System" Version="2.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bonsai.Harp/Bonsai.Harp.csproj
+++ b/Bonsai.Harp/Bonsai.Harp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.7.2" />
+    <PackageReference Include="Bonsai.Core" Version="2.7.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Bonsai.Harp/MessageWriter.cs
+++ b/Bonsai.Harp/MessageWriter.cs
@@ -1,0 +1,43 @@
+﻿using System.ComponentModel;
+using System.IO;
+using Bonsai.IO;
+
+namespace Bonsai.Harp
+{
+    /// <summary>
+    /// Represents an operator that writes each Harp message in the sequence
+    /// to a raw binary output stream.
+    /// </summary>
+    [Description("Writes each Harp message in the sequence to a raw binary output stream.")]
+    public class MessageWriter : StreamSink<HarpMessage, BinaryWriter>
+    {
+        /// <summary>
+        /// Creates a binary writer over the specified <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The stream on which the elements should be written.</param>
+        /// <returns>
+        /// A <see cref="BinaryWriter"/> object used to write binary array data
+        /// into the stream.
+        /// </returns>
+        protected override BinaryWriter CreateWriter(Stream stream)
+        {
+            return new BinaryWriter(stream);
+        }
+
+        /// <summary>
+        /// Writes a new Harp message to the raw binary output stream.
+        /// </summary>
+        /// <param name="writer">
+        /// A <see cref="BinaryWriter"/> object used to write binary message data to
+        /// the output stream.
+        /// </param>
+        /// <param name="input">
+        /// The Harp message containing the binary data to write into the output
+        /// stream.
+        /// </param>
+        protected override void Write(BinaryWriter writer, HarpMessage input)
+        {
+            writer.Write(input.MessageBytes);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new operator for logging Harp messages. The first implementation of the `MessageWriter` operator simply writes the raw message bytes into the specified stream, but pending resolution of https://github.com/bonsai-rx/bonsai/issues/1309 this could be easily generalized to support writing one binary stream per register when receiving a stream of grouped observables.

Fixes #25 