### PR TITLE
Avoid console writes when device ID is specified

### DIFF
--- a/Bonsai.Harp/Device.cs
+++ b/Bonsai.Harp/Device.cs
@@ -145,11 +145,14 @@ namespace Bonsai.Harp
             set
             {
                 portName = value;
-                GetDeviceName(deviceId, portName, LedState, VisualIndicators, Heartbeat).Subscribe(deviceName => name = deviceName);
+                if (deviceId == 0)
+                {
+                    GetDeviceName(portName, LedState, VisualIndicators, Heartbeat).Subscribe(deviceName => name = deviceName);
+                }
             }
         }
 
-        static IObservable<string> GetDeviceName(int deviceId, string portName, LedState ledState, LedState visualIndicators, EnableFlag heartbeat)
+        static IObservable<string> GetDeviceName(string portName, LedState ledState, LedState visualIndicators, EnableFlag heartbeat)
         {
             return Observable.Create<string>(observer =>
             {
@@ -203,7 +206,6 @@ namespace Bonsai.Harp
                                 var deviceName = nameof(Device);
                                 if (!message.Error) deviceName = DeviceName.GetPayload(message);
                                 Console.WriteLine("Serial Harp device.");
-                                if (deviceId > 0 && deviceId != whoAmI) Console.WriteLine("WARNING: Unexpected device identifier!");
                                 if (!serialNumber.HasValue) Console.WriteLine($"WhoAmI: {whoAmI}");
                                 else Console.WriteLine($"WhoAmI: {whoAmI}-{serialNumber:x4}");
                                 Console.WriteLine($"Hw: {hardwareVersionHigh}.{hardwareVersionLow}");


### PR DESCRIPTION
This PR removes the behavior of writing information to the standard output when the `PortName` property changes. To keep backwards-compatibility the behavior is kept when the device identifier (`whoAmI`) is left with its default value of zero. This is the case when using the debug `Device` class.

Updating the name of the device dynamically is not so important when using a well-defined high-level interface, since the device node will always display the name of the device anyway, and other information can be found in the default editor dialog.

Fixes #22 