### PR TITLE
Assert identifier and firmware version

### DIFF
--- a/Bonsai.Harp/AsyncDevice.cs
+++ b/Bonsai.Harp/AsyncDevice.cs
@@ -10,6 +10,7 @@ namespace Bonsai.Harp
     /// </summary>
     public class AsyncDevice : IDisposable
     {
+        readonly bool _leaveOpen;
         readonly SerialTransport transport;
         readonly Subject<HarpMessage> response;
 
@@ -24,6 +25,17 @@ namespace Bonsai.Harp
             transport = new SerialTransport(portName, response);
             transport.IgnoreErrors = true;
             transport.Open();
+        }
+
+        internal AsyncDevice(string portName, bool leaveOpen)
+            : this(portName)
+        {
+            _leaveOpen = leaveOpen;
+        }
+
+        internal SerialTransport Transport
+        {
+            get { return transport; }
         }
 
         /// <summary>
@@ -721,7 +733,10 @@ namespace Bonsai.Harp
         /// </summary>
         public void Dispose()
         {
-            transport.Close();
+            if (!_leaveOpen)
+            {
+                transport.Close();
+            }
             response.Dispose();
         }
     }

--- a/Bonsai.Harp/Bootloader.cs
+++ b/Bonsai.Harp/Bootloader.cs
@@ -138,15 +138,6 @@ namespace Bonsai.Harp
             }
         }
 
-        static async Task<T> WithTimeout<T>(this Task<T> task, int millisecondsDelay)
-        {
-            if (await Task.WhenAny(task, Task.Delay(millisecondsDelay)) == task)
-            {
-                return task.Result;
-            }
-            else throw new TimeoutException("There was a timeout while awaiting the device response.");
-        }
-
         static ushort GetMessageChecksum(byte[] messageBytes)
         {
             var checksum = (ushort)0;

--- a/Bonsai.Harp/TaskExtensions.cs
+++ b/Bonsai.Harp/TaskExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Bonsai.Harp
+{
+    static class TaskExtensions
+    {
+        internal static async Task<T> WithTimeout<T>(this Task<T> task, int millisecondsDelay)
+        {
+            if (await Task.WhenAny(task, Task.Delay(millisecondsDelay)) == task)
+            {
+                return task.Result;
+            }
+            else throw new TimeoutException("There was a timeout while awaiting the device response.");
+        }
+    }
+}


### PR DESCRIPTION
This PR verifies the device identifier and firmware version registers against specified metadata. The checks are performed asynchronously at device initialization time, and any pending invalid messages in the serial port buffer are flushed.

Even if no device-specific metadata is provided, the implementation will attempt to perform a register read command on the [WHO_AM_I](https://harp-tech.org/About/How-HARP-works/common_registers_operation_devices.html#r-who-am-i-who-am-i) register with a 500 ms timeout. This ensures that the device on the other side of the serial port can at least implement a simple register exchange following the Harp protocol.

Fixes #20 
Fixes #53 