### PR TITLE
Improve support for timestamped payload manipulation

### DIFF
--- a/Bonsai.Harp/CreateMessageBuilder.cs
+++ b/Bonsai.Harp/CreateMessageBuilder.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Reflection;
 using System.Xml.Serialization;
-using Bonsai.Expressions;
 
 namespace Bonsai.Harp
 {
@@ -15,7 +18,17 @@ namespace Bonsai.Harp
     [WorkflowElementCategory(ElementCategory.Source)]
     public abstract class CreateMessageBuilder : HarpCombinatorBuilder
     {
-        readonly CombinatorBuilder builder = new CombinatorBuilder();
+        static readonly Range<int> argumentRange = Range.Create(lowerBound: 0, upperBound: 1);
+
+        /// <inheritdoc/>
+        public override Range<int> ArgumentRange => argumentRange;
+
+        /// <summary>
+        /// Gets or sets a value specifying the type of the created message.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("Specifies the type of the created message.")]
+        public MessageType MessageType { get; set; } = MessageType.Write;
 
         /// <summary>
         /// Gets or sets the operator used to create specific Harp device message payloads.
@@ -29,16 +42,107 @@ namespace Bonsai.Harp
         public object Payload
         {
             get { return Operator; }
-            set { builder.Combinator = Operator = value; }
+            set { Operator = value; }
         }
-
-        /// <inheritdoc/>
-        public override Range<int> ArgumentRange => builder.ArgumentRange;
 
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)
         {
-            return builder.Build(arguments);
+            var source = arguments.FirstOrDefault();
+            var payload = Expression.Constant(Payload);
+            var messageType = Expression.Parameter(typeof(MessageType));
+            var combinator = Expression.Constant(this, typeof(CreateMessageBuilder));
+
+            var timestamped = false;
+            MethodInfo getMessage = null;
+            var getMessageOverloads = payload.Type.FindMembers(
+                MemberTypes.Method,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                Type.FilterName,
+                nameof(CreateMessagePayload.GetMessage));
+            for (int i = 0; i < getMessageOverloads.Length; i++)
+            {
+                var method = (MethodInfo)getMessageOverloads[i];
+                var methodParameters = method.GetParameters();
+                if (methodParameters.Length == 0 || methodParameters.Length > 2 ||
+                    methodParameters[methodParameters.Length - 1].ParameterType != typeof(MessageType))
+                {
+                    continue;
+                }
+
+                if (methodParameters.Length == 1 && getMessage == null) getMessage = method;
+                else if (methodParameters[0].ParameterType == typeof(double) &&
+                    (payload.Value is not CreateMessagePayload createMessage ||
+                    (createMessage.PayloadType & PayloadType.Timestamp) != 0))
+                {
+                    timestamped = true;
+                    getMessage = method;
+                }
+            }
+
+            if (getMessage == null)
+            {
+                throw new InvalidOperationException("No compatible method overload found for the given arguments.");
+            }
+
+            if (timestamped)
+            {
+                var timestamp = Expression.Parameter(typeof(double));
+                var selector = Expression.Lambda(
+                    Expression.Call(payload, getMessage, timestamp, messageType),
+                    timestamp,
+                    messageType);
+                var sourceType = source.Type.GetGenericArguments()[0];
+                var typeArguments = sourceType != typeof(HarpMessage) && sourceType.IsGenericType
+                    ? new[] { sourceType.GetGenericArguments()[0] }
+                    : null;
+                return Expression.Call(
+                    combinator,
+                    nameof(ProcessTimestamped),
+                    typeArguments,
+                    source,
+                    selector);
+            }
+            else
+            {
+                var selector = Expression.Lambda(
+                    Expression.Call(payload, getMessage, messageType),
+                    messageType);
+                if (source == null)
+                {
+                    return Expression.Call(combinator, nameof(Process), null, selector);
+                }
+                else
+                {
+                    var sourceType = source.Type.GetGenericArguments()[0];
+                    return Expression.Call(
+                        combinator,
+                        nameof(Process),
+                        new[] { sourceType },
+                        source,
+                        selector);
+                }
+            }
+        }
+
+        IObservable<HarpMessage> Process(Func<MessageType, HarpMessage> selector)
+        {
+            return Observable.Defer(() => Observable.Return(selector(MessageType)));
+        }
+
+        IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source, Func<MessageType, HarpMessage> selector)
+        {
+            return source.Select(_ => selector(MessageType));
+        }
+
+        IObservable<HarpMessage> ProcessTimestamped(IObservable<HarpMessage> source, Func<double, MessageType, HarpMessage> selector)
+        {
+            return source.Select(message => selector(message.GetTimestamp(), MessageType));
+        }
+
+        IObservable<HarpMessage> ProcessTimestamped<TSource>(IObservable<Timestamped<TSource>> source, Func<double, MessageType, HarpMessage> selector)
+        {
+            return source.Select(_ => selector(_.Seconds, MessageType));
         }
     }
 }

--- a/Bonsai.Harp/CreateMessageBuilder.cs
+++ b/Bonsai.Harp/CreateMessageBuilder.cs
@@ -87,6 +87,11 @@ namespace Bonsai.Harp
 
             if (timestamped)
             {
+                if (source == null)
+                {
+                    throw new InvalidOperationException("Creating timestamped messages requires a source input.");
+                }
+
                 var timestamp = Expression.Parameter(typeof(double));
                 var selector = Expression.Lambda(
                     Expression.Call(payload, getMessage, timestamp, messageType),

--- a/Bonsai.Harp/CreateTimestamped.cs
+++ b/Bonsai.Harp/CreateTimestamped.cs
@@ -47,5 +47,21 @@ namespace Bonsai.Harp
         {
             return source.Select(value => Timestamped.Create(value.Item1, value.Item2.GetTimestamp()));
         }
+
+        /// <summary>
+        /// Creates an observable sequence of timestamped message values surfacing the
+        /// timestamp of the message object in fractional seconds.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of timestamped <see cref="HarpMessage"/> objects.
+        /// </param>
+        /// <returns>
+        /// An observable sequence of timestamped values representing the original
+        /// message and its timestamp, in fractional seconds.
+        /// </returns>
+        public IObservable<Timestamped<HarpMessage>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Select(message => Timestamped.Create(message, message.GetTimestamp()));
+        }
     }
 }

--- a/Bonsai.Harp/Device.Generated.cs
+++ b/Bonsai.Harp/Device.Generated.cs
@@ -1514,493 +1514,552 @@ namespace Bonsai.Harp
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a message payload
     /// that specifies the identity class of the device.
     /// </summary>
     [DisplayName("WhoAmIPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the identity class of the device.")]
-    public partial class CreateWhoAmIPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the identity class of the device.")]
+    public partial class CreateWhoAmIPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the identity class of the device.
         /// </summary>
         [Description("The value that specifies the identity class of the device.")]
-        public int Value { get; set; }
+        public int WhoAmI { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the identity class of the device.
+        /// Creates a message payload for the WhoAmI register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public int GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return WhoAmI;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the identity class of the device.
+        /// Creates a message that specifies the identity class of the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the WhoAmI register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => WhoAmI.FromPayload(MessageType, Value));
+            return Bonsai.Harp.WhoAmI.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the identity class of the device.
+    /// </summary>
+    [DisplayName("TimestampedWhoAmIPayload")]
+    [Description("Creates a timestamped message payload that specifies the identity class of the device.")]
+    public partial class CreateTimestampedWhoAmIPayload : CreateWhoAmIPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the identity class of the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the WhoAmI register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.WhoAmI.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the major hardware version of the device.
     /// </summary>
     [DisplayName("HardwareVersionHighPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the major hardware version of the device.")]
-    public partial class CreateHardwareVersionHighPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the major hardware version of the device.")]
+    public partial class CreateHardwareVersionHighPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the major hardware version of the device.
         /// </summary>
         [Description("The value that specifies the major hardware version of the device.")]
-        public byte Value { get; set; }
+        public byte HardwareVersionHigh { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the major hardware version of the device.
+        /// Creates a message payload for the HardwareVersionHigh register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public byte GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return HardwareVersionHigh;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the major hardware version of the device.
+        /// Creates a message that specifies the major hardware version of the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the HardwareVersionHigh register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => HardwareVersionHigh.FromPayload(MessageType, Value));
+            return Bonsai.Harp.HardwareVersionHigh.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the major hardware version of the device.
+    /// </summary>
+    [DisplayName("TimestampedHardwareVersionHighPayload")]
+    [Description("Creates a timestamped message payload that specifies the major hardware version of the device.")]
+    public partial class CreateTimestampedHardwareVersionHighPayload : CreateHardwareVersionHighPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the major hardware version of the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the HardwareVersionHigh register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.HardwareVersionHigh.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the minor hardware version of the device.
     /// </summary>
     [DisplayName("HardwareVersionLowPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the minor hardware version of the device.")]
-    public partial class CreateHardwareVersionLowPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the minor hardware version of the device.")]
+    public partial class CreateHardwareVersionLowPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the minor hardware version of the device.
         /// </summary>
         [Description("The value that specifies the minor hardware version of the device.")]
-        public byte Value { get; set; }
+        public byte HardwareVersionLow { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the minor hardware version of the device.
+        /// Creates a message payload for the HardwareVersionLow register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public byte GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return HardwareVersionLow;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the minor hardware version of the device.
+        /// Creates a message that specifies the minor hardware version of the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the HardwareVersionLow register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => HardwareVersionLow.FromPayload(MessageType, Value));
+            return Bonsai.Harp.HardwareVersionLow.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the minor hardware version of the device.
+    /// </summary>
+    [DisplayName("TimestampedHardwareVersionLowPayload")]
+    [Description("Creates a timestamped message payload that specifies the minor hardware version of the device.")]
+    public partial class CreateTimestampedHardwareVersionLowPayload : CreateHardwareVersionLowPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the minor hardware version of the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the HardwareVersionLow register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.HardwareVersionLow.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the version of the assembled components in the device.
     /// </summary>
     [DisplayName("AssemblyVersionPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the version of the assembled components in the device.")]
-    public partial class CreateAssemblyVersionPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the version of the assembled components in the device.")]
+    public partial class CreateAssemblyVersionPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the version of the assembled components in the device.
         /// </summary>
         [Description("The value that specifies the version of the assembled components in the device.")]
-        public byte Value { get; set; }
+        public byte AssemblyVersion { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the version of the assembled components in the device.
+        /// Creates a message payload for the AssemblyVersion register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public byte GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return AssemblyVersion;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the version of the assembled components in the device.
+        /// Creates a message that specifies the version of the assembled components in the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the AssemblyVersion register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => AssemblyVersion.FromPayload(MessageType, Value));
+            return Bonsai.Harp.AssemblyVersion.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the version of the assembled components in the device.
+    /// </summary>
+    [DisplayName("TimestampedAssemblyVersionPayload")]
+    [Description("Creates a timestamped message payload that specifies the version of the assembled components in the device.")]
+    public partial class CreateTimestampedAssemblyVersionPayload : CreateAssemblyVersionPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the version of the assembled components in the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the AssemblyVersion register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.AssemblyVersion.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the major version of the Harp core implemented by the device.
     /// </summary>
     [DisplayName("CoreVersionHighPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the major version of the Harp core implemented by the device.")]
-    public partial class CreateCoreVersionHighPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the major version of the Harp core implemented by the device.")]
+    public partial class CreateCoreVersionHighPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the major version of the Harp core implemented by the device.
         /// </summary>
         [Description("The value that specifies the major version of the Harp core implemented by the device.")]
-        public byte Value { get; set; }
+        public byte CoreVersionHigh { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the major version of the Harp core implemented by the device.
+        /// Creates a message payload for the CoreVersionHigh register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public byte GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return CoreVersionHigh;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the major version of the Harp core implemented by the device.
+        /// Creates a message that specifies the major version of the Harp core implemented by the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the CoreVersionHigh register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => CoreVersionHigh.FromPayload(MessageType, Value));
+            return Bonsai.Harp.CoreVersionHigh.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the major version of the Harp core implemented by the device.
+    /// </summary>
+    [DisplayName("TimestampedCoreVersionHighPayload")]
+    [Description("Creates a timestamped message payload that specifies the major version of the Harp core implemented by the device.")]
+    public partial class CreateTimestampedCoreVersionHighPayload : CreateCoreVersionHighPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the major version of the Harp core implemented by the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the CoreVersionHigh register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.CoreVersionHigh.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the minor version of the Harp core implemented by the device.
     /// </summary>
     [DisplayName("CoreVersionLowPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the minor version of the Harp core implemented by the device.")]
-    public partial class CreateCoreVersionLowPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the minor version of the Harp core implemented by the device.")]
+    public partial class CreateCoreVersionLowPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the minor version of the Harp core implemented by the device.
         /// </summary>
         [Description("The value that specifies the minor version of the Harp core implemented by the device.")]
-        public byte Value { get; set; }
+        public byte CoreVersionLow { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the minor version of the Harp core implemented by the device.
+        /// Creates a message payload for the CoreVersionLow register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public byte GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return CoreVersionLow;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the minor version of the Harp core implemented by the device.
+        /// Creates a message that specifies the minor version of the Harp core implemented by the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the CoreVersionLow register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => CoreVersionLow.FromPayload(MessageType, Value));
+            return Bonsai.Harp.CoreVersionLow.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the minor version of the Harp core implemented by the device.
+    /// </summary>
+    [DisplayName("TimestampedCoreVersionLowPayload")]
+    [Description("Creates a timestamped message payload that specifies the minor version of the Harp core implemented by the device.")]
+    public partial class CreateTimestampedCoreVersionLowPayload : CreateCoreVersionLowPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the minor version of the Harp core implemented by the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the CoreVersionLow register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.CoreVersionLow.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the major version of the Harp core implemented by the device.
     /// </summary>
     [DisplayName("FirmwareVersionHighPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the major version of the Harp core implemented by the device.")]
-    public partial class CreateFirmwareVersionHighPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the major version of the Harp core implemented by the device.")]
+    public partial class CreateFirmwareVersionHighPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the major version of the Harp core implemented by the device.
         /// </summary>
         [Description("The value that specifies the major version of the Harp core implemented by the device.")]
-        public byte Value { get; set; }
+        public byte FirmwareVersionHigh { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the major version of the Harp core implemented by the device.
+        /// Creates a message payload for the FirmwareVersionHigh register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public byte GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return FirmwareVersionHigh;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the major version of the Harp core implemented by the device.
+        /// Creates a message that specifies the major version of the Harp core implemented by the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the FirmwareVersionHigh register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => FirmwareVersionHigh.FromPayload(MessageType, Value));
+            return Bonsai.Harp.FirmwareVersionHigh.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the major version of the Harp core implemented by the device.
+    /// </summary>
+    [DisplayName("TimestampedFirmwareVersionHighPayload")]
+    [Description("Creates a timestamped message payload that specifies the major version of the Harp core implemented by the device.")]
+    public partial class CreateTimestampedFirmwareVersionHighPayload : CreateFirmwareVersionHighPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the major version of the Harp core implemented by the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the FirmwareVersionHigh register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.FirmwareVersionHigh.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the minor version of the Harp core implemented by the device.
     /// </summary>
     [DisplayName("FirmwareVersionLowPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the minor version of the Harp core implemented by the device.")]
-    public partial class CreateFirmwareVersionLowPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the minor version of the Harp core implemented by the device.")]
+    public partial class CreateFirmwareVersionLowPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the minor version of the Harp core implemented by the device.
         /// </summary>
         [Description("The value that specifies the minor version of the Harp core implemented by the device.")]
-        public byte Value { get; set; }
+        public byte FirmwareVersionLow { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the minor version of the Harp core implemented by the device.
+        /// Creates a message payload for the FirmwareVersionLow register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public byte GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return FirmwareVersionLow;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the minor version of the Harp core implemented by the device.
+        /// Creates a message that specifies the minor version of the Harp core implemented by the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the FirmwareVersionLow register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => FirmwareVersionLow.FromPayload(MessageType, Value));
+            return Bonsai.Harp.FirmwareVersionLow.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the minor version of the Harp core implemented by the device.
+    /// </summary>
+    [DisplayName("TimestampedFirmwareVersionLowPayload")]
+    [Description("Creates a timestamped message payload that specifies the minor version of the Harp core implemented by the device.")]
+    public partial class CreateTimestampedFirmwareVersionLowPayload : CreateFirmwareVersionLowPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the minor version of the Harp core implemented by the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the FirmwareVersionLow register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.FirmwareVersionLow.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that stores the integral part of the system timestamp, in seconds.
     /// </summary>
     [DisplayName("TimestampSecondsPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that stores the integral part of the system timestamp, in seconds.")]
-    public partial class CreateTimestampSecondsPayload : HarpCombinator
+    [Description("Creates a message payload that stores the integral part of the system timestamp, in seconds.")]
+    public partial class CreateTimestampSecondsPayload
     {
         /// <summary>
         /// Gets or sets the value that stores the integral part of the system timestamp, in seconds.
         /// </summary>
         [Description("The value that stores the integral part of the system timestamp, in seconds.")]
-        public uint Value { get; set; }
+        public uint TimestampSeconds { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that stores the integral part of the system timestamp, in seconds.
+        /// Creates a message payload for the TimestampSeconds register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public uint GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return TimestampSeconds;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that stores the integral part of the system timestamp, in seconds.
+        /// Creates a message that stores the integral part of the system timestamp, in seconds.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the TimestampSeconds register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => TimestampSeconds.FromPayload(MessageType, Value));
+            return Bonsai.Harp.TimestampSeconds.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that stores the integral part of the system timestamp, in seconds.
+    /// </summary>
+    [DisplayName("TimestampedTimestampSecondsPayload")]
+    [Description("Creates a timestamped message payload that stores the integral part of the system timestamp, in seconds.")]
+    public partial class CreateTimestampedTimestampSecondsPayload : CreateTimestampSecondsPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that stores the integral part of the system timestamp, in seconds.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the TimestampSeconds register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.TimestampSeconds.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that stores the fractional part of the system timestamp, in microseconds.
     /// </summary>
     [DisplayName("TimestampMicrosecondsPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that stores the fractional part of the system timestamp, in microseconds.")]
-    public partial class CreateTimestampMicrosecondsPayload : HarpCombinator
+    [Description("Creates a message payload that stores the fractional part of the system timestamp, in microseconds.")]
+    public partial class CreateTimestampMicrosecondsPayload
     {
         /// <summary>
         /// Gets or sets the value that stores the fractional part of the system timestamp, in microseconds.
         /// </summary>
         [Description("The value that stores the fractional part of the system timestamp, in microseconds.")]
-        public ushort Value { get; set; }
+        public ushort TimestampMicroseconds { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that stores the fractional part of the system timestamp, in microseconds.
+        /// Creates a message payload for the TimestampMicroseconds register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public ushort GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return TimestampMicroseconds;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that stores the fractional part of the system timestamp, in microseconds.
+        /// Creates a message that stores the fractional part of the system timestamp, in microseconds.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the TimestampMicroseconds register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => TimestampMicroseconds.FromPayload(MessageType, Value));
+            return Bonsai.Harp.TimestampMicroseconds.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that stores the fractional part of the system timestamp, in microseconds.
+    /// </summary>
+    [DisplayName("TimestampedTimestampMicrosecondsPayload")]
+    [Description("Creates a timestamped message payload that stores the fractional part of the system timestamp, in microseconds.")]
+    public partial class CreateTimestampedTimestampMicrosecondsPayload : CreateTimestampMicrosecondsPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that stores the fractional part of the system timestamp, in microseconds.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the TimestampMicroseconds register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.TimestampMicroseconds.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that stores the configuration mode of the device.
     /// </summary>
     [DisplayName("OperationControlPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that stores the configuration mode of the device.")]
-    public partial class CreateOperationControlPayload : HarpCombinator
+    [Description("Creates a message payload that stores the configuration mode of the device.")]
+    public partial class CreateOperationControlPayload
     {
         /// <summary>
         /// Gets or sets a value that specifies the operation mode of the device.
@@ -2039,237 +2098,265 @@ namespace Bonsai.Harp
         public EnableFlag Heartbeat { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that stores the configuration mode of the device.
+        /// Creates a message payload for the OperationControl register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public OperationControlPayload GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            OperationControlPayload value;
+            value.OperationMode = OperationMode;
+            value.DumpRegisters = DumpRegisters;
+            value.MuteReplies = MuteReplies;
+            value.VisualIndicators = VisualIndicators;
+            value.OperationLed = OperationLed;
+            value.Heartbeat = Heartbeat;
+            return value;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that stores the configuration mode of the device.
+        /// Creates a message that stores the configuration mode of the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the OperationControl register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ =>
-            {
-                OperationControlPayload value;
-                value.OperationMode = OperationMode;
-                value.DumpRegisters = DumpRegisters;
-                value.MuteReplies = MuteReplies;
-                value.VisualIndicators = VisualIndicators;
-                value.OperationLed = OperationLed;
-                value.Heartbeat = Heartbeat;
-                return OperationControl.FromPayload(MessageType, value);
-            });
+            return Bonsai.Harp.OperationControl.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that stores the configuration mode of the device.
+    /// </summary>
+    [DisplayName("TimestampedOperationControlPayload")]
+    [Description("Creates a timestamped message payload that stores the configuration mode of the device.")]
+    public partial class CreateTimestampedOperationControlPayload : CreateOperationControlPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that stores the configuration mode of the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the OperationControl register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.OperationControl.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that resets the device and saves non-volatile registers.
     /// </summary>
     [DisplayName("ResetDevicePayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that resets the device and saves non-volatile registers.")]
-    public partial class CreateResetDevicePayload : HarpCombinator
+    [Description("Creates a message payload that resets the device and saves non-volatile registers.")]
+    public partial class CreateResetDevicePayload
     {
         /// <summary>
         /// Gets or sets the value that resets the device and saves non-volatile registers.
         /// </summary>
         [Description("The value that resets the device and saves non-volatile registers.")]
-        public ResetFlags Value { get; set; }
+        public ResetFlags ResetDevice { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that resets the device and saves non-volatile registers.
+        /// Creates a message payload for the ResetDevice register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public ResetFlags GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return ResetDevice;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that resets the device and saves non-volatile registers.
+        /// Creates a message that resets the device and saves non-volatile registers.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the ResetDevice register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => ResetDevice.FromPayload(MessageType, Value));
+            return Bonsai.Harp.ResetDevice.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that resets the device and saves non-volatile registers.
+    /// </summary>
+    [DisplayName("TimestampedResetDevicePayload")]
+    [Description("Creates a timestamped message payload that resets the device and saves non-volatile registers.")]
+    public partial class CreateTimestampedResetDevicePayload : CreateResetDevicePayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that resets the device and saves non-volatile registers.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the ResetDevice register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.ResetDevice.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that stores the user-specified device name.
     /// </summary>
     [DisplayName("DeviceNamePayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that stores the user-specified device name.")]
-    public partial class CreateDeviceNamePayload : HarpCombinator
+    [Description("Creates a message payload that stores the user-specified device name.")]
+    public partial class CreateDeviceNamePayload
     {
         /// <summary>
         /// Gets or sets the value that stores the user-specified device name.
         /// </summary>
         [Description("The value that stores the user-specified device name.")]
-        public string Value { get; set; }
+        public string DeviceName { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that stores the user-specified device name.
+        /// Creates a message payload for the DeviceName register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public string GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return DeviceName;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that stores the user-specified device name.
+        /// Creates a message that stores the user-specified device name.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the DeviceName register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => DeviceName.FromPayload(MessageType, Value));
+            return Bonsai.Harp.DeviceName.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that stores the user-specified device name.
+    /// </summary>
+    [DisplayName("TimestampedDeviceNamePayload")]
+    [Description("Creates a timestamped message payload that stores the user-specified device name.")]
+    public partial class CreateTimestampedDeviceNamePayload : CreateDeviceNamePayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that stores the user-specified device name.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the DeviceName register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.DeviceName.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the unique serial number of the device.
     /// </summary>
     [DisplayName("SerialNumberPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the unique serial number of the device.")]
-    public partial class CreateSerialNumberPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the unique serial number of the device.")]
+    public partial class CreateSerialNumberPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the unique serial number of the device.
         /// </summary>
         [Description("The value that specifies the unique serial number of the device.")]
-        public ushort Value { get; set; }
+        public ushort SerialNumber { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the unique serial number of the device.
+        /// Creates a message payload for the SerialNumber register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public ushort GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return SerialNumber;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the unique serial number of the device.
+        /// Creates a message that specifies the unique serial number of the device.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the SerialNumber register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => SerialNumber.FromPayload(MessageType, Value));
+            return Bonsai.Harp.SerialNumber.FromPayload(messageType, GetPayload());
         }
     }
 
     /// <summary>
-    /// Represents an operator that creates a sequence of message payloads
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the unique serial number of the device.
+    /// </summary>
+    [DisplayName("TimestampedSerialNumberPayload")]
+    [Description("Creates a timestamped message payload that specifies the unique serial number of the device.")]
+    public partial class CreateTimestampedSerialNumberPayload : CreateSerialNumberPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the unique serial number of the device.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the SerialNumber register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.SerialNumber.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
     /// that specifies the configuration for the device synchronization clock.
     /// </summary>
     [DisplayName("ClockConfigurationPayload")]
-    [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Creates a sequence of message payloads that specifies the configuration for the device synchronization clock.")]
-    public partial class CreateClockConfigurationPayload : HarpCombinator
+    [Description("Creates a message payload that specifies the configuration for the device synchronization clock.")]
+    public partial class CreateClockConfigurationPayload
     {
         /// <summary>
         /// Gets or sets the value that specifies the configuration for the device synchronization clock.
         /// </summary>
         [Description("The value that specifies the configuration for the device synchronization clock.")]
-        public ClockConfigurationFlags Value { get; set; }
+        public ClockConfigurationFlags ClockConfiguration { get; set; }
 
         /// <summary>
-        /// Creates an observable sequence that contains a single message
-        /// that specifies the configuration for the device synchronization clock.
+        /// Creates a message payload for the ClockConfiguration register.
         /// </summary>
-        /// <returns>
-        /// A sequence containing a single <see cref="HarpMessage"/> object
-        /// representing the created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process()
+        /// <returns>The created message payload value.</returns>
+        public ClockConfigurationFlags GetPayload()
         {
-            return Process(Observable.Return(System.Reactive.Unit.Default));
+            return ClockConfiguration;
         }
 
         /// <summary>
-        /// Creates an observable sequence of message payloads
-        /// that specifies the configuration for the device synchronization clock.
+        /// Creates a message that specifies the configuration for the device synchronization clock.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for emitting message payloads.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing each
-        /// created message payload.
-        /// </returns>
-        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the ClockConfiguration register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
         {
-            return source.Select(_ => ClockConfiguration.FromPayload(MessageType, Value));
+            return Bonsai.Harp.ClockConfiguration.FromPayload(messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a timestamped message payload
+    /// that specifies the configuration for the device synchronization clock.
+    /// </summary>
+    [DisplayName("TimestampedClockConfigurationPayload")]
+    [Description("Creates a timestamped message payload that specifies the configuration for the device synchronization clock.")]
+    public partial class CreateTimestampedClockConfigurationPayload : CreateClockConfigurationPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message that specifies the configuration for the device synchronization clock.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the ClockConfiguration register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Bonsai.Harp.ClockConfiguration.FromPayload(timestamp, messageType, GetPayload());
         }
     }
 

--- a/Bonsai.Harp/DeviceCommand.cs
+++ b/Bonsai.Harp/DeviceCommand.cs
@@ -112,37 +112,4 @@ namespace Bonsai.Harp
             return source.Select(value => HarpCommand.WriteUInt32(DeviceRegisters.TimestampSecond, value));
         }
     }
-
-    /// <summary>
-    /// Represents an operator that creates a command message to set the value of
-    /// the timestamp register in the Harp device to the current UTC time of the host.
-    /// </summary>
-    [Description("Creates a command message to set the value of the timestamp register in the Harp device to the current UTC time of the host.")]
-    public class SynchronizeTimestamp : Combinator<HarpMessage>
-    {
-        /// <summary>
-        /// Creates an observable sequence of command messages to set the value of
-        /// the timestamp register in the Harp device to the current UTC time of
-        /// the host.
-        /// </summary>
-        /// <typeparam name="TSource">
-        /// The type of the elements in the <paramref name="source"/> sequence.
-        /// </typeparam>
-        /// <param name="source">
-        /// The sequence containing the notifications used for creating new command
-        /// messages.
-        /// </param>
-        /// <returns>
-        /// A sequence of <see cref="HarpMessage"/> objects representing the command
-        /// to set the value of the timestamp register in the Harp device.
-        /// </returns>
-        public override IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
-        {
-            return source.Select(_ =>
-            {
-                var timestamp = (uint)DateTime.UtcNow.Subtract(CreateTimestamped.ReferenceTime).TotalSeconds;
-                return TimestampSeconds.FromPayload(MessageType.Write, timestamp);
-            });
-        }
-    }
 }

--- a/Bonsai.Harp/DeviceCommand.cs
+++ b/Bonsai.Harp/DeviceCommand.cs
@@ -117,8 +117,6 @@ namespace Bonsai.Harp
     /// Represents an operator that creates a command message to set the value of
     /// the timestamp register in the Harp device to the current UTC time of the host.
     /// </summary>
-    [Obsolete]
-    [DesignTimeVisible(false)]
     [Description("Creates a command message to set the value of the timestamp register in the Harp device to the current UTC time of the host.")]
     public class SynchronizeTimestamp : Combinator<HarpMessage>
     {
@@ -143,7 +141,7 @@ namespace Bonsai.Harp
             return source.Select(_ =>
             {
                 var timestamp = (uint)DateTime.UtcNow.Subtract(CreateTimestamped.ReferenceTime).TotalSeconds;
-                return HarpCommand.WriteUInt32(DeviceRegisters.TimestampSecond, timestamp);
+                return TimestampSeconds.FromPayload(MessageType.Write, timestamp);
             });
         }
     }

--- a/Bonsai.Harp/DeviceCommand.cs
+++ b/Bonsai.Harp/DeviceCommand.cs
@@ -142,8 +142,8 @@ namespace Bonsai.Harp
         {
             return source.Select(_ =>
             {
-                var unixTimestamp = (uint)(DateTime.UtcNow.Subtract(new DateTime(1904, 1, 1))).TotalSeconds;
-                return HarpCommand.WriteUInt32(DeviceRegisters.TimestampSecond, unixTimestamp);
+                var timestamp = (uint)DateTime.UtcNow.Subtract(CreateTimestamped.ReferenceTime).TotalSeconds;
+                return HarpCommand.WriteUInt32(DeviceRegisters.TimestampSecond, timestamp);
             });
         }
     }

--- a/Bonsai.Harp/Format.cs
+++ b/Bonsai.Harp/Format.cs
@@ -89,7 +89,7 @@ namespace Bonsai.Harp
         [EditorBrowsable(EditorBrowsableState.Never)]
         public PayloadType PayloadType
         {
-            get { return Register is FormatMessagePayload formatMessage ? formatMessage.PayloadType : default; }
+            get => Register is FormatMessagePayload formatMessage ? formatMessage.PayloadType.GetValueOrDefault() : default;
             set { if (Register is FormatMessagePayload formatMessage) formatMessage.PayloadType = value; }
         }
 
@@ -140,7 +140,7 @@ namespace Bonsai.Harp
         /// Gets or sets the type of data to include in the message payload.
         /// </summary>
         [Description("The type of data to include in the message payload.")]
-        public PayloadType PayloadType { get; set; } = PayloadType.U8;
+        public PayloadType? PayloadType { get; set; } = Harp.PayloadType.U8;
 
         static Expression GetAddressExpression(Expression expression, int? address)
         {
@@ -159,6 +159,23 @@ namespace Bonsai.Harp
             return Expression.PropertyOrField(expression, nameof(HarpMessage.Address));
         }
 
+        static Expression GetPayloadTypeExpression(Expression expression, PayloadType? payloadType)
+        {
+            if (payloadType.HasValue && payloadType.GetValueOrDefault() != Harp.PayloadType.Timestamp)
+            {
+                return Expression.Constant(payloadType.GetValueOrDefault());
+            }
+
+            if (expression.Type != typeof(HarpMessage))
+            {
+                throw new ArgumentException(
+                    "The source value must be a Harp message if no payload type is specified.",
+                    nameof(expression));
+            }
+
+            return Expression.PropertyOrField(expression, nameof(HarpMessage.PayloadType));
+        }
+
         /// <summary>
         /// Returns the expression that specifies how a valid Harp message is created
         /// from the input data.
@@ -172,8 +189,8 @@ namespace Bonsai.Harp
         {
             Expression[] arguments;
             var payloadType = PayloadType;
-            var baseType = payloadType & ~PayloadType.Timestamp;
-            var timestamped = (payloadType & PayloadType.Timestamp) == PayloadType.Timestamp;
+            var baseType = payloadType & ~Harp.PayloadType.Timestamp;
+            var timestamped = (payloadType & Harp.PayloadType.Timestamp) == Harp.PayloadType.Timestamp;
             var address = GetAddressExpression(expression, Address);
             var messageType = Expression.Constant(MessageType);
             if (timestamped)
@@ -190,50 +207,65 @@ namespace Bonsai.Harp
                     expression = Expression.PropertyOrField(expression, nameof(Timestamped<object>.Value));
                 }
 
-                if (TryGetArraySegment(ref expression))
+                var payloadTypeExpression = GetPayloadTypeExpression(expression, payloadType);
+                if (TryGetArraySegment(expression, out Expression payload))
                 {
-                    arguments = new[] { address, timestamp, messageType, Expression.Constant(payloadType), expression };
+                    arguments = new[] { address, timestamp, messageType, payloadTypeExpression, payload };
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromPayload), null, arguments);
                 }
                 arguments = new[] { address, timestamp, messageType, expression };
             }
             else
             {
-                if (TryGetArraySegment(ref expression))
+                var payloadTypeExpression = GetPayloadTypeExpression(expression, payloadType);
+                if (TryGetArraySegment(expression, out Expression payload))
                 {
-                    arguments = new[] { address, messageType, Expression.Constant(payloadType), expression };
-                    return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromPayload), null, arguments);
+                    arguments = new[] { address, messageType, payloadTypeExpression, payload };
+                    var fromPayload = Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromPayload), null, arguments);
+                    if (payloadType == null && expression.Type == typeof(HarpMessage))
+                    {
+                        var timestamp = Expression.Variable(typeof(double));
+                        var isTimestamped = Expression.Call(expression, nameof(HarpMessage.TryGetTimestamp), null, timestamp);
+                        arguments = new[] { address, timestamp, messageType, payloadTypeExpression, payload };
+                        return Expression.Block(
+                            new[] { timestamp },
+                            Expression.Condition(
+                                isTimestamped,
+                                Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromPayload), null, arguments),
+                                fromPayload));
+                    }
+                    else return fromPayload;
                 }
                 arguments = new[] { address, messageType, expression };
             }
 
             switch (baseType)
             {
-                case PayloadType.U8:
+                case Harp.PayloadType.U8:
                     EnsurePayloadType(arguments, expression, typeof(byte));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromByte), null, arguments);
-                case PayloadType.S8:
+                case Harp.PayloadType.S8:
                     EnsurePayloadType(arguments, expression, typeof(sbyte));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromSByte), null, arguments);
-                case PayloadType.U16:
+                case Harp.PayloadType.U16:
                     EnsurePayloadType(arguments, expression, typeof(ushort));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromUInt16), null, arguments);
-                case PayloadType.S16:
+                case Harp.PayloadType.S16:
                     EnsurePayloadType(arguments, expression, typeof(short));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromInt16), null, arguments);
-                case PayloadType.U32:
+                case Harp.PayloadType.U32:
                     EnsurePayloadType(arguments, expression, typeof(uint));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromUInt32), null, arguments);
-                case PayloadType.S32:
+                case Harp.PayloadType.S32:
                     EnsurePayloadType(arguments, expression, typeof(int));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromInt32), null, arguments);
-                case PayloadType.U64:
+                case Harp.PayloadType.U64:
                     EnsurePayloadType(arguments, expression, typeof(ulong));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromUInt64), null, arguments);
-                case PayloadType.S64:
+                case Harp.PayloadType.S64:
                     EnsurePayloadType(arguments, expression, typeof(long));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromInt64), null, arguments);
-                case PayloadType.Float:
+                case Harp.PayloadType.Float:
                     EnsurePayloadType(arguments, expression, typeof(float));
                     return Expression.Call(typeof(HarpMessage), nameof(HarpMessage.FromSingle), null, arguments);
                 default:
@@ -241,20 +273,29 @@ namespace Bonsai.Harp
             }
         }
 
-        static bool TryGetArraySegment(ref Expression expression)
+        static bool TryGetArraySegment(Expression expression, out Expression payload)
         {
             if (expression.Type == typeof(HarpMessage))
             {
-                expression = Expression.Call(expression, nameof(HarpMessage.GetPayload), null);
+                payload = Expression.Call(expression, nameof(HarpMessage.GetPayload), null);
                 return true;
             }
-            return expression.Type == typeof(ArraySegment<byte>);
+            else if (expression.Type == typeof(ArraySegment<byte>))
+            {
+                payload = expression;
+                return true;
+            }
+            else
+            {
+                payload = null;
+                return false;
+            }
         }
 
         static void EnsurePayloadType(Expression[] arguments, Expression payload, Type type)
         {
             if (type != typeof(float)) payload = payload.Type.IsArray ? payload : Expression.Convert(payload, type);
-            else payload = payload.Type.IsArray? payload : Expression.NewArrayInit(type, Expression.Convert(payload, type));
+            else payload = payload.Type.IsArray ? payload : Expression.NewArrayInit(type, Expression.Convert(payload, type));
             arguments[arguments.Length - 1] = payload;
         }
     }

--- a/Bonsai.Harp/FormatBuilder.cs
+++ b/Bonsai.Harp/FormatBuilder.cs
@@ -28,7 +28,7 @@ namespace Bonsai.Harp
         /// </summary>
         [Category(nameof(CategoryAttribute.Design))]
         [Description("Specifies the type of the formatted message.")]
-        public MessageType MessageType { get; set; } = MessageType.Write;
+        public MessageType? MessageType { get; set; } = Harp.MessageType.Write;
 
         /// <summary>
         /// Gets or sets the operator used to format the source data into specific
@@ -112,14 +112,12 @@ namespace Bonsai.Harp
 
         IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source, Func<MessageType, TSource, HarpMessage> selector)
         {
-            var messageType = MessageType;
-            return source.Select(payload => selector(messageType, payload));
+            return source.Select(payload => selector(MessageType.Value, payload));
         }
 
         IObservable<HarpMessage> Process<TSource>(IObservable<Timestamped<TSource>> source, Func<double, MessageType, TSource, HarpMessage> selector)
         {
-            var messageType = MessageType;
-            return source.Select(payload => selector(payload.Seconds, messageType, payload.Value));
+            return source.Select(payload => selector(payload.Seconds, MessageType.Value, payload.Value));
         }
     }
 }

--- a/Bonsai.Harp/FormatBuilder.cs
+++ b/Bonsai.Harp/FormatBuilder.cs
@@ -110,8 +110,6 @@ namespace Bonsai.Harp
                 selector);
         }
 
-
-
         IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source, Func<MessageType, TSource, HarpMessage> selector)
         {
             var messageType = MessageType;

--- a/Bonsai.Harp/HarpMessage.cs
+++ b/Bonsai.Harp/HarpMessage.cs
@@ -948,7 +948,7 @@ namespace Bonsai.Harp
             messageBytes[0] = (byte)messageType;
             messageBytes[2] = (byte)address;
             messageBytes[3] = (byte)port;
-            messageBytes[4] = (byte)payloadType;
+            messageBytes[4] = (byte)(payloadType | PayloadType.Timestamp);
             Buffer.BlockCopy(payload, 0, messageBytes, TimestampedOffset, payloadSize);
             return FromBytes(timestamp, messageBytes);
         }
@@ -1104,7 +1104,7 @@ namespace Bonsai.Harp
             messageBytes[0] = (byte)messageType;
             messageBytes[2] = (byte)address;
             messageBytes[3] = (byte)port;
-            messageBytes[4] = (byte)payloadType;
+            messageBytes[4] = (byte)(payloadType | PayloadType.Timestamp);
             Buffer.BlockCopy(payload.Array, payload.Offset, messageBytes, TimestampedOffset, payload.Count);
             return FromBytes(timestamp, messageBytes);
         }

--- a/Bonsai.Harp/OffsetTimestamp.cs
+++ b/Bonsai.Harp/OffsetTimestamp.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+using System.Xml;
+
+namespace Bonsai.Harp
+{
+    /// <summary>
+    /// Represents an operator that shifts the timestamps of a sequence of timestamped payload
+    /// values by the specified time interval.
+    /// </summary>
+    [Combinator]
+    [Description("Shifts the timestamps of a sequence of timestamped payload values by the specified time interval.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class OffsetTimestamp
+    {
+        double? offsetSeconds;
+
+        /// <summary>
+        /// Gets or sets a time interval by which to offset the sequence timestamps.
+        /// </summary>
+        [XmlIgnore]
+        [Description("The time interval by which to offset the sequence timestamps.")]
+        public TimeSpan? TimeShift
+        {
+            get => offsetSeconds.HasValue
+                ? TimeSpan.FromSeconds(offsetSeconds.GetValueOrDefault())
+                : default(TimeSpan?);
+            set => offsetSeconds = value?.TotalSeconds;
+        }
+
+        /// <summary>
+        /// Gets or sets an XML representation of the offset time interval for serialization.
+        /// </summary>
+        [Browsable(false)]
+        [XmlElement(nameof(TimeShift))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string TimeShiftXml
+        {
+            get
+            {
+                var timeShift = TimeShift;
+                if (timeShift.HasValue) return XmlConvert.ToString(timeShift.Value);
+                else return null;
+            }
+            set
+            {
+                if (!string.IsNullOrEmpty(value)) TimeShift = XmlConvert.ToTimeSpan(value);
+                else TimeShift = null;
+            }
+        }
+
+        /// <summary>
+        /// Shifts the timestamps of an observable sequence of timestamped payload values
+        /// by the specified offset.
+        /// </summary>
+        /// <typeparam name="T">The type of the values in each timestamped payload.</typeparam>
+        /// <param name="source">An observable sequence of timestamped payload values.</param>
+        /// <returns>
+        /// A sequence of timestamped payload values where each timestamp is computed by adding
+        /// the time interval offset to the timestamp of the corresponding payload in the
+        /// <paramref name="source"/> sequence.
+        /// </returns>
+        public IObservable<Timestamped<T>> Process<T>(IObservable<Timestamped<T>> source)
+        {
+            return source.Select(x => Timestamped.Create(
+                x.Value,
+                x.Seconds + offsetSeconds.GetValueOrDefault()));
+        }
+
+        /// <summary>
+        /// Shifts the timestamps of an observable sequence of timestamped payload values
+        /// by the specified offset, in fractional seconds.
+        /// </summary>
+        /// <typeparam name="T">The type of the values in each timestamped payload.</typeparam>
+        /// <param name="source">
+        /// A sequence of pairs containing a timestamped payload and a time interval, in
+        /// fractional seconds, by which to offset the payload timestamp.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped payload values where each timestamp is computed by adding
+        /// both the seconds offset and the base <see cref="TimeShift"/> offset to the timestamp
+        /// of the corresponding payload in the <paramref name="source"/> sequence.
+        /// </returns>
+        public IObservable<Timestamped<T>> Process<T>(IObservable<Tuple<Timestamped<T>, double>> source)
+        {
+            return source.Select(x => Timestamped.Create(
+                x.Item1.Value,
+                x.Item1.Seconds + x.Item2 + offsetSeconds.GetValueOrDefault()));
+        }
+
+        /// <summary>
+        /// Shifts the timestamps of an observable sequence of timestamped payload values
+        /// by the specified time interval.
+        /// </summary>
+        /// <typeparam name="T">The type of the values in each timestamped payload.</typeparam>
+        /// <param name="source">
+        /// A sequence of pairs containing a timestamped payload and the time interval by
+        /// which to offset the payload timestamp.
+        /// </param>
+        /// <returns>
+        /// A sequence of timestamped payload values where each timestamp is computed by adding
+        /// both the time interval and the base <see cref="TimeShift"/> offset to the timestamp
+        /// of the corresponding payload in the <paramref name="source"/> sequence.
+        /// </returns>
+        public IObservable<Timestamped<T>> Process<T>(IObservable<Tuple<Timestamped<T>, TimeSpan>> source)
+        {
+            return source.Select(x => Timestamped.Create(
+                x.Item1.Value,
+                x.Item1.Seconds + x.Item2.TotalSeconds + offsetSeconds.GetValueOrDefault()));
+        }
+    }
+}

--- a/Bonsai.Harp/SynchronizeTimestamp.cs
+++ b/Bonsai.Harp/SynchronizeTimestamp.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace Bonsai.Harp
+{
+    /// <summary>
+    /// Represents an operator that creates a command message to set the value of
+    /// the timestamp register in the Harp device to the current UTC time of the host.
+    /// </summary>
+    [Description("Creates a command message to set the value of the timestamp register in the Harp device to the current UTC time of the host.")]
+    public class SynchronizeTimestamp : Combinator<HarpMessage>
+    {
+        /// <summary>
+        /// Creates an observable sequence of command messages to set the value of
+        /// the timestamp register in the Harp device to the current UTC time of
+        /// the host.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for creating new command
+        /// messages.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing the command
+        /// to set the value of the timestamp register in the Harp device.
+        /// </returns>
+        public override IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ =>
+            {
+                var timestamp = (uint)DateTime.UtcNow.Subtract(CreateTimestamped.ReferenceTime).TotalSeconds;
+                return TimestampSeconds.FromPayload(MessageType.Write, timestamp);
+            });
+        }
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/bonsai-rx/harp.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <VersionSuffix></VersionSuffix>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Features>strict</Features>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR rewrites the interface of the core `Format` and `CreateMessage` polymorphic operators to make it easier to modify and inject custom timestamps into all created messages. For the `CreateMessage` polymorphic types, it assumes a structure of both non-timestamped and timestamped types, mirroring the one in use for registers, that indicates whether payloads are intended to be created with a timestamp.

The flexibility of `Format` has also been improved to allow modifying and reshaping every available general attribute of Harp messages, including address, message type, payload type and timestamp. This makes it possible to edit streams of messages in a much more general way.

New overloads for `CreateTimestamped` and a new operator `OffsetTimestamp` have been introduced to make it easier to manipulate and edit timestamped streams, and also to convert local host UTC times into Harp times.

Finally, the `SynchronizeTimestamp` has been "revived" as a convenient shorthand syntax to create the complete message to synchronize the host UTC clock with the device clock.

Fixes #56 