### PR TITLE
Refactor serial transport to avoid event callbacks

### DIFF
--- a/Bonsai.Harp/AsyncDevice.cs
+++ b/Bonsai.Harp/AsyncDevice.cs
@@ -24,8 +24,6 @@ namespace Bonsai.Harp
         {
             response = new Subject<HarpMessage>();
             transport = new SerialTransport(portName, response);
-            transport.IgnoreErrors = true;
-            transport.Open();
         }
 
         internal AsyncDevice(string portName, bool leaveOpen)

--- a/Bonsai.Harp/BufferedStream.cs
+++ b/Bonsai.Harp/BufferedStream.cs
@@ -70,14 +70,14 @@ namespace Bonsai.Harp
             if (writeOffset >= readOffset)
             {
                 bytesWritten = Math.Min(readBuffer.Length - writeOffset, count);
-                serialStream.Read(readBuffer, writeOffset, bytesWritten);
+                bytesWritten = serialStream.Read(readBuffer, writeOffset, bytesWritten);
                 writeOffset = (writeOffset + bytesWritten) % readBuffer.Length;
                 count -= bytesWritten;
                 if (count == 0) return bytesWritten;
             }
 
             var remaining = Math.Min(readOffset - writeOffset, count);
-            serialStream.Read(readBuffer, writeOffset, remaining);
+            remaining = serialStream.Read(readBuffer, writeOffset, remaining);
             writeOffset = (writeOffset + remaining) % readBuffer.Length;
             return bytesWritten + remaining;
         }

--- a/Bonsai.Harp/FileDevice.cs
+++ b/Bonsai.Harp/FileDevice.cs
@@ -15,75 +15,6 @@ namespace Bonsai.Harp
     [Description("Produces a sequence of Harp messages from a previously recorded data file.")]
     public class FileDevice : Source<HarpMessage>
     {
-        readonly IObservable<HarpMessage> source;
-        readonly object captureLock = new object();
-        const int ReadBufferSize = 4096;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FileDevice"/> class.
-        /// </summary>
-        public FileDevice()
-        {
-            PlaybackRate = 1;
-            source = Observable.Create<HarpMessage>((observer, cancellationToken) =>
-            {
-                return Task.Factory.StartNew(() =>
-                {
-                    lock (captureLock)
-                    {
-                        using (var stream = new FileStream(FileName, FileMode.Open))
-                        using (var waitSignal = new ManualResetEvent(false))
-                        {
-                            double timestampOffset = 0;
-                            var stopwatch = new Stopwatch();
-
-                            var harpObserver = Observer.Create<HarpMessage>(
-                                value =>
-                                {
-                                    var playbackRate = PlaybackRate;
-                                    if (playbackRate.HasValue && value.TryGetTimestamp(out double timestamp))
-                                    {
-                                        timestamp *= 1000.0 / playbackRate.Value; //ms
-                                        if (!stopwatch.IsRunning ||
-                                            value.MessageType == MessageType.Write &&
-                                            value.Address == TimestampSeconds.Address &&
-                                            value.PayloadType == (PayloadType.Timestamp | TimestampSeconds.RegisterType))
-                                        {
-                                            stopwatch.Restart();
-                                            timestampOffset = timestamp;
-                                        }
-
-                                        var waitInterval = timestamp - timestampOffset - stopwatch.ElapsedMilliseconds;
-                                        if (waitInterval > 0)
-                                        {
-                                            waitSignal.WaitOne((int)waitInterval);
-                                        }
-                                    }
-
-                                    observer.OnNext(value);
-                                },
-                                observer.OnError,
-                                observer.OnCompleted);
-                            var transport = new StreamTransport(harpObserver);
-                            transport.IgnoreErrors = IgnoreErrors;
-
-                            long bytesToRead;
-                            while (!cancellationToken.IsCancellationRequested &&
-                                   (bytesToRead = Math.Min(ReadBufferSize, stream.Length - stream.Position)) > 0)
-                            {
-                                transport.ReceiveData(stream, ReadBufferSize, (int)bytesToRead);
-                            }
-                        }
-                    }
-                },
-                cancellationToken,
-                TaskCreationOptions.LongRunning,
-                TaskScheduler.Default);
-            })
-            .PublishReconnectable()
-            .RefCount();
-        }
-
         /// <summary>
         /// Gets or sets the path to the binary file containing Harp messages to playback.
         /// </summary>
@@ -102,7 +33,7 @@ namespace Bonsai.Harp
         /// no rate is specified, playback will be done as fast as possible.
         /// </summary>
         [Description("The optional rate multiplier to either slowdown or speedup the playback. If no rate is specified, playback will be done as fast as possible.")]
-        public double? PlaybackRate { get; set; }
+        public double? PlaybackRate { get; set; } = 1;
 
         /// <summary>
         /// Opens the specified file name and returns the observable sequence of Harp messages
@@ -111,7 +42,59 @@ namespace Bonsai.Harp
         /// <returns>The observable sequence of Harp messages stored in the binary file.</returns>
         public override IObservable<HarpMessage> Generate()
         {
-            return source;
+            const int ReadBufferSize = 4096;
+            var fileName = FileName;
+            var ignoreErrors = IgnoreErrors;
+            return Observable.Create<HarpMessage>((observer, cancellationToken) =>
+            {
+                return Task.Factory.StartNew(() =>
+                {
+                    using var stream = new FileStream(fileName, FileMode.Open);
+                    using var waitSignal = new ManualResetEvent(false);
+                    double timestampOffset = 0;
+                    var stopwatch = new Stopwatch();
+
+                    var harpObserver = Observer.Create<HarpMessage>(
+                        value =>
+                        {
+                            var playbackRate = PlaybackRate;
+                            if (playbackRate.HasValue && value.TryGetTimestamp(out double timestamp))
+                            {
+                                timestamp *= 1000.0 / playbackRate.Value; //ms
+                                if (!stopwatch.IsRunning ||
+                                    value.MessageType == MessageType.Write &&
+                                    value.Address == TimestampSeconds.Address &&
+                                    value.PayloadType == (PayloadType.Timestamp | TimestampSeconds.RegisterType))
+                                {
+                                    stopwatch.Restart();
+                                    timestampOffset = timestamp;
+                                }
+
+                                var waitInterval = timestamp - timestampOffset - stopwatch.ElapsedMilliseconds;
+                                if (waitInterval > 0)
+                                {
+                                    waitSignal.WaitOne((int)waitInterval);
+                                }
+                            }
+
+                            observer.OnNext(value);
+                        },
+                        observer.OnError,
+                        observer.OnCompleted);
+                    var transport = new StreamTransport(harpObserver);
+                    transport.IgnoreErrors = ignoreErrors;
+
+                    long bytesToRead;
+                    while (!cancellationToken.IsCancellationRequested &&
+                           (bytesToRead = Math.Min(ReadBufferSize, stream.Length - stream.Position)) > 0)
+                    {
+                        transport.ReceiveData(stream, ReadBufferSize, (int)bytesToRead);
+                    }
+                },
+                cancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+            });
         }
     }
 }

--- a/Bonsai.Harp/StreamTransport.cs
+++ b/Bonsai.Harp/StreamTransport.cs
@@ -51,12 +51,18 @@ namespace Bonsai.Harp
             return true;
         }
 
+        internal void PushData(Stream stream, int readBufferSize, int count)
+        {
+            bufferedStream = bufferedStream ?? new BufferedStream(stream, readBufferSize);
+            bufferedStream.PushBytes(count);
+        }
+
         internal void ReceiveData(Stream stream, int readBufferSize, int bytesToRead)
         {
             try
             {
-                bufferedStream = bufferedStream ?? new BufferedStream(stream, readBufferSize);
-                bufferedStream.PushBytes(bytesToRead);
+                PushData(stream, readBufferSize, bytesToRead);
+                bytesToRead = bufferedStream.BytesToRead;
 
                 while (bytesToRead > 0)
                 {
@@ -140,8 +146,13 @@ namespace Bonsai.Harp
             }
             catch (Exception ex)
             {
-                observer.OnError(ex);
+                OnError(ex);
             }
+        }
+
+        internal void OnError(Exception error)
+        {
+            observer.OnError(error);
         }
     }
 }


### PR DESCRIPTION
Following on developments from https://github.com/bonsai-rx/bonsai/pull/1444 this PR refactors the serial transport layer to avoid event callbacks. This has the advantage of both eliminating dispose deadlocks and making all Harp interfaces compatible with Mono, e.g. for running on Linux desktop, Raspberry Pi, Unity3D, etc.

Fixes #62 