### PR TITLE
Add timeline visualizer for Harp message streams

### DIFF
--- a/Bonsai.Harp.Visualizers/Bonsai.Harp.Visualizers.csproj
+++ b/Bonsai.Harp.Visualizers/Bonsai.Harp.Visualizers.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <Title>Bonsai - Harp Visualizers Library</Title>
+    <Description>Bonsai Design Library containing operators for visualizing Harp message streams.</Description>
+    <PackageTags>Bonsai Rx Harp Visualizers</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <UseWindowsForms>true</UseWindowsForms>
+    <TargetFramework>net472</TargetFramework>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bonsai.Design.Visualizers" Version="2.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai.Harp.Design\Bonsai.Harp.Design.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Bonsai.Harp.Visualizers/BoundedPointPairList.cs
+++ b/Bonsai.Harp.Visualizers/BoundedPointPairList.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using ZedGraph;
+
+namespace Bonsai.Harp.Visualizers
+{
+    internal class BoundedPointPairList : IPointListEdit
+    {
+        double minValue = double.MinValue;
+        double maxValue = double.MaxValue;
+        readonly QueueList<PointPair> points = new();
+
+        public BoundedPointPairList()
+        {
+        }
+
+        public BoundedPointPairList(IPointList points)
+        {
+            for (int i = 0; i < points.Count; i++)
+            {
+                Add(points[i]);
+            }
+        }
+
+        public void SetBounds(double min, double max)
+        {
+            if (max < min)
+            {
+                throw new ArgumentOutOfRangeException(nameof(max));
+            }
+
+            minValue = min;
+            maxValue = max;
+            while (points.Count > 0 && points[0].X < min)
+            {
+                points.TryDequeue(out _);
+            }
+
+            while (points.Count > 0 && points[points.Count - 1].X > max)
+            {
+                points.TryDequeueLast(out _);
+            }
+        }
+
+        public PointPair this[int index]
+        {
+            get => points[index];
+            set => points[index] = value;
+        }
+
+        PointPair IPointList.this[int index] => this[index];
+
+        public int Count => points.Count;
+
+        public void Add(PointPair point)
+        {
+            if (point.X >= minValue && point.X <= maxValue)
+            {
+                points.Enqueue(point);
+            }
+        }
+
+        public void Add(double x, double y)
+        {
+            if (x >= minValue && x <= maxValue)
+            {
+                points.Enqueue(new PointPair(x, y));
+            }
+        }
+
+        public void Clear()
+        {
+            points.Clear();
+        }
+
+        public object Clone()
+        {
+            return new BoundedPointPairList(this);
+        }
+
+        public void RemoveAt(int index)
+        {
+            points.RemoveAt(index);
+        }
+    }
+}

--- a/Bonsai.Harp.Visualizers/GraphHelper.cs
+++ b/Bonsai.Harp.Visualizers/GraphHelper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using ZedGraph;
+
+namespace Bonsai.Harp.Visualizers
+{
+    static class GraphHelper
+    {
+        internal static void SetAxisLabel(Axis axis, string label)
+        {
+            axis.Title.Text = label;
+            axis.Title.IsVisible = !string.IsNullOrEmpty(label);
+        }
+
+        internal static void FormatTimeAxis(Axis axis)
+        {
+            axis.Type = AxisType.Linear;
+            axis.Scale.MaxAuto = false;
+            axis.Scale.MinAuto = false;
+        }
+    }
+}

--- a/Bonsai.Harp.Visualizers/Properties/AssemblyInfo.cs
+++ b/Bonsai.Harp.Visualizers/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:Bonsai.Harp.Visualizers", "harpviz")]
+[assembly: WorkflowNamespaceIcon("Bonsai:ElementIcon.Visualizer")]

--- a/Bonsai.Harp.Visualizers/Properties/launchSettings.json
+++ b/Bonsai.Harp.Visualizers/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Executable",
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/Bonsai.Harp.Visualizers/QueueList.cs
+++ b/Bonsai.Harp.Visualizers/QueueList.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bonsai.Harp.Visualizers
+{
+    internal class QueueList<T> : IReadOnlyList<T>
+    {
+        int head;
+        int tail;
+        int count;
+        T[] buffer;
+
+        public QueueList() : this(capacity: 4)
+        {
+        }
+
+        public QueueList(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            EnsureCapacity(capacity);
+        }
+
+        private void EnsureCapacity(int capacity)
+        {
+            var array = new T[capacity];
+            if (count > 0)
+            {
+                if (head < tail)
+                {
+                    Array.Copy(buffer, head, array, 0, count);
+                }
+                else
+                {
+                    Array.Copy(buffer, head, array, 0, buffer.Length - head);
+                    Array.Copy(buffer, 0, array, buffer.Length - head, tail);
+                }
+            }
+
+            buffer = array;
+            head = 0;
+            tail = count;
+        }
+
+        private int GetIndexInternal(int index)
+        {
+            return (head + index) % buffer.Length;
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return buffer[GetIndexInternal(index)];
+            }
+            set
+            {
+                if (index < 0 || index >= count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                buffer[GetIndexInternal(index)] = value;
+            }
+        }
+
+        public int Count => count;
+
+        public void Enqueue(T item)
+        {
+            if (count >= buffer.Length)
+            {
+                EnsureCapacity(buffer.Length * 2);
+            }
+
+            buffer[tail] = item;
+            tail = (tail + 1) % buffer.Length;
+            count++;
+        }
+
+        public bool TryDequeue(out T result)
+        {
+            if (count == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            result = buffer[head];
+            buffer[head] = default;
+            head = (head + 1) % buffer.Length;
+            count--;
+            return true;
+        }
+
+        public bool TryDequeueLast(out T result)
+        {
+            if (count == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            var index = tail - 1;
+            if (index < 0) index += buffer.Length;
+            result = buffer[index];
+            buffer[index] = default;
+            tail = index;
+            count--;
+            return true;
+        }
+
+        public void Clear()
+        {
+            if (head < tail)
+            {
+                Array.Clear(buffer, head, count);
+            }
+            else
+            {
+                Array.Clear(buffer, head, buffer.Length - head);
+                Array.Clear(buffer, 0, tail);
+            }
+
+            head = 0;
+            tail = 0;
+            count = 0;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return buffer[GetIndexInternal(i)];
+            }
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Bonsai.Harp.Visualizers/TimelineGraph.cs
+++ b/Bonsai.Harp.Visualizers/TimelineGraph.cs
@@ -1,0 +1,133 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+using Bonsai.Design.Visualizers;
+using ZedGraph;
+
+namespace Bonsai.Harp.Visualizers
+{
+    internal class TimelineGraph : GraphControl
+    {
+        bool autoScaleX;
+        bool autoScaleY;
+
+        public TimelineGraph()
+        {
+            autoScaleX = true;
+            autoScaleY = true;
+            IsShowContextMenu = false;
+            ZoomEvent += RollingGraph_ZoomEvent;
+        }
+
+        public double XMin
+        {
+            get { return GraphPane.XAxis.Scale.Min; }
+            set
+            {
+                GraphPane.XAxis.Scale.Min = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double XMax
+        {
+            get { return GraphPane.XAxis.Scale.Max; }
+            set
+            {
+                GraphPane.XAxis.Scale.Max = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double YMin
+        {
+            get { return GraphPane.YAxis.Scale.Min; }
+            set
+            {
+                GraphPane.YAxis.Scale.Min = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double YMax
+        {
+            get { return GraphPane.YAxis.Scale.Max; }
+            set
+            {
+                GraphPane.YAxis.Scale.Max = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public bool AutoScaleX
+        {
+            get { return autoScaleX; }
+            set
+            {
+                var changed = autoScaleX != value;
+                autoScaleX = value;
+                if (changed)
+                {
+                    GraphPane.XAxis.Scale.MaxAuto = autoScaleX;
+                    GraphPane.XAxis.Scale.MinAuto = autoScaleX;
+                    if (autoScaleX) Invalidate();
+                }
+            }
+        }
+
+        public bool AutoScaleY
+        {
+            get { return autoScaleY; }
+            set
+            {
+                var changed = autoScaleY != value;
+                autoScaleY = value;
+                if (changed)
+                {
+                    GraphPane.YAxis.Scale.MaxAuto = autoScaleY;
+                    GraphPane.YAxis.Scale.MinAuto = autoScaleY;
+                    if (autoScaleY) Invalidate();
+                }
+            }
+        }
+
+        internal CurveItem CreateSeries(string label, IPointListEdit points, Color color)
+        {
+            var curve = new LineItem(label, points, color, SymbolType.Circle, lineWidth: 0);
+            curve.Line.IsAntiAlias = false;
+            curve.Line.IsOptimizedDraw = true;
+            curve.Label.IsVisible = !string.IsNullOrEmpty(label);
+            curve.Symbol.Fill.Type = FillType.Solid;
+            curve.Symbol.IsAntiAlias = true;
+            return curve;
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.P)
+            {
+                DoPrint();
+            }
+
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.S)
+            {
+                SaveAs();
+            }
+
+            if (e.KeyCode == Keys.Back)
+            {
+                ZoomOut(GraphPane);
+            }
+
+            base.OnKeyDown(e);
+        }
+
+        private void RollingGraph_ZoomEvent(ZedGraphControl sender, ZoomState oldState, ZoomState newState)
+        {
+            MasterPane.AxisChange();
+        }
+    }
+}

--- a/Bonsai.Harp.Visualizers/TimelineGraphBuilder.cs
+++ b/Bonsai.Harp.Visualizers/TimelineGraphBuilder.cs
@@ -47,6 +47,14 @@ namespace Bonsai.Harp.Visualizers
             return Expression.Call(combinator, nameof(Process), null, source);
         }
 
+        IObservable<HarpMessage> Process(IObservable<HarpMessage> source)
+        {
+            return source.Publish(ps => ps.Merge(
+                Process(ps.GroupBy(message => message.Address))
+                .IgnoreElements()
+                .Select(_ => default(HarpMessage))));
+        }
+
         IObservable<IGroupedObservable<int, HarpMessage>> Process(IObservable<IGroupedObservable<int, HarpMessage>> source)
         {
             return source.Do(Controller.Registers.OnNext);

--- a/Bonsai.Harp.Visualizers/TimelineGraphBuilder.cs
+++ b/Bonsai.Harp.Visualizers/TimelineGraphBuilder.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Bonsai.Expressions;
+
+namespace Bonsai.Harp.Visualizers
+{
+    /// <summary>
+    /// Represents an operator that configures a visualizer to plot each Harp message
+    /// in the sequence in a synchronized rolling graph.
+    /// </summary>
+    [TypeVisualizer(typeof(TimelineGraphVisualizer))]
+    [Description("A visualizer that plots each Harp message in the sequence in a synchronized rolling graph.")]
+    public class TimelineGraphBuilder : SingleArgumentExpressionBuilder
+    {
+        /// <summary>
+        /// Gets or sets the optional maximum time range captured in the timeline graph.
+        /// If no time span is specified, all data points will be displayed.
+        /// </summary>
+        [Category("Range")]
+        [Description("The optional maximum time range captured in the timeline graph. If no time span is specified, all data points will be displayed.")]
+        public double? TimeSpan { get; set; }
+
+        internal VisualizerController Controller { get; set; }
+
+        internal class VisualizerController
+        {
+            internal double? TimeSpan;
+            internal ReplaySubject<IObservable<HarpMessage>> Registers;
+        }
+
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.First();
+            var parameterType = source.Type.GetGenericArguments()[0];
+            Controller = new VisualizerController
+            {
+                TimeSpan = TimeSpan,
+                Registers = new ReplaySubject<IObservable<HarpMessage>>()
+            };
+            var combinator = Expression.Constant(this);
+            return Expression.Call(combinator, nameof(Process), null, source);
+        }
+
+        IObservable<IGroupedObservable<int, HarpMessage>> Process(IObservable<IGroupedObservable<int, HarpMessage>> source)
+        {
+            return source.Do(Controller.Registers.OnNext);
+        }
+
+        IObservable<IGroupedObservable<Type, HarpMessage>> Process(IObservable<IGroupedObservable<Type, HarpMessage>> source)
+        {
+            return source.Do(Controller.Registers.OnNext);
+        }
+    }
+}

--- a/Bonsai.Harp.Visualizers/TimelineGraphView.Designer.cs
+++ b/Bonsai.Harp.Visualizers/TimelineGraphView.Designer.cs
@@ -1,0 +1,111 @@
+﻿namespace Bonsai.Harp.Visualizers
+{
+    partial class TimelineGraphView
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.cursorStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.timeSpanStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.timeSpanValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.graph = new Bonsai.Harp.Visualizers.TimelineGraph();
+            this.statusStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // statusStrip
+            // 
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cursorStatusLabel,
+            this.timeSpanStatusLabel,
+            this.timeSpanValueLabel});
+            this.statusStrip.Location = new System.Drawing.Point(0, 218);
+            this.statusStrip.Name = "statusStrip";
+            this.statusStrip.Size = new System.Drawing.Size(400, 22);
+            this.statusStrip.TabIndex = 1;
+            this.statusStrip.Text = "statusStrip";
+            this.statusStrip.Visible = false;
+            // 
+            // cursorStatusLabel
+            // 
+            this.cursorStatusLabel.Name = "cursorStatusLabel";
+            this.cursorStatusLabel.Size = new System.Drawing.Size(45, 17);
+            this.cursorStatusLabel.Text = "Cursor:";
+            // 
+            // timeSpanStatusLabel
+            // 
+            this.timeSpanStatusLabel.Name = "timeSpanStatusLabel";
+            this.timeSpanStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.timeSpanStatusLabel.Text = "TimeSpan:";
+            // 
+            // timeSpanValueLabel
+            // 
+            this.timeSpanValueLabel.Name = "timeSpanValueLabel";
+            this.timeSpanValueLabel.Size = new System.Drawing.Size(12, 17);
+            this.timeSpanValueLabel.Text = "count";
+            // 
+            // graph
+            // 
+            this.graph.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.graph.Location = new System.Drawing.Point(0, 0);
+            this.graph.Name = "graph";
+            this.graph.ScrollGrace = 0D;
+            this.graph.ScrollMaxX = 0D;
+            this.graph.ScrollMaxY = 0D;
+            this.graph.ScrollMaxY2 = 0D;
+            this.graph.ScrollMinX = 0D;
+            this.graph.ScrollMinY = 0D;
+            this.graph.ScrollMinY2 = 0D;
+            this.graph.Size = new System.Drawing.Size(400, 218);
+            this.graph.TabIndex = 2;
+            this.graph.MouseMoveEvent += new ZedGraph.ZedGraphControl.ZedMouseEventHandler(this.graph_MouseMoveEvent);
+            this.graph.MouseClick += new System.Windows.Forms.MouseEventHandler(this.graph_MouseClick);
+            // 
+            // TimelineGraphView
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.graph);
+            this.Controls.Add(this.statusStrip);
+            this.Name = "TimelineGraphView";
+            this.Size = new System.Drawing.Size(400, 240);
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.StatusStrip statusStrip;
+        private Bonsai.Harp.Visualizers.TimelineGraph graph;
+        private System.Windows.Forms.ToolStripStatusLabel cursorStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel timeSpanStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel timeSpanValueLabel;
+    }
+}

--- a/Bonsai.Harp.Visualizers/TimelineGraphView.cs
+++ b/Bonsai.Harp.Visualizers/TimelineGraphView.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Windows.Forms;
+using ZedGraph;
+using System.Globalization;
+
+namespace Bonsai.Harp.Visualizers
+{
+    partial class TimelineGraphView : UserControl
+    {
+        readonly ToolStripEditableLabel timeSpanEditableLabel;
+
+        public TimelineGraphView()
+        {
+            InitializeComponent();
+            timeSpanEditableLabel = new ToolStripEditableLabel(timeSpanValueLabel, OnTimeSpanEdit);
+            Graph.GraphPane.AxisChangeEvent += GraphPane_AxisChangeEvent;
+            components.Add(timeSpanEditableLabel);
+        }
+
+        protected StatusStrip StatusStrip
+        {
+            get { return statusStrip; }
+        }
+
+        public TimelineGraph Graph
+        {
+            get { return graph; }
+        }
+
+        public double TimeSpan { get; set; }
+
+        public bool CanEditTimeSpan
+        {
+            get { return timeSpanEditableLabel.Enabled; }
+            set { timeSpanEditableLabel.Enabled = value; }
+        }
+
+        public event EventHandler AxisChanged;
+
+        protected virtual void OnAxisChanged(EventArgs e)
+        {
+            AxisChanged?.Invoke(this, e);
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+        }
+
+        private bool graph_MouseMoveEvent(ZedGraphControl sender, MouseEventArgs e)
+        {
+            var pane = graph.MasterPane.FindChartRect(e.Location);
+            if (pane != null)
+            {
+                pane.ReverseTransform(e.Location, out double x, out double y);
+                cursorStatusLabel.Text = string.Format("Cursor: ({0:F0}, {1:G5})", x, y);
+            }
+            return false;
+        }
+
+        private void graph_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                statusStrip.Visible = !statusStrip.Visible;
+            }
+        }
+
+        private void GraphPane_AxisChangeEvent(GraphPane pane)
+        {
+            var timeSpan = TimeSpan;
+            timeSpanValueLabel.Text = timeSpan.ToString(CultureInfo.InvariantCulture);
+            OnAxisChanged(EventArgs.Empty);
+        }
+
+        private void OnTimeSpanEdit(string text)
+        {
+            if (int.TryParse(text, out int timeSpan))
+            {
+                TimeSpan = timeSpan;
+            }
+        }
+    }
+}

--- a/Bonsai.Harp.Visualizers/TimelineGraphView.resx
+++ b/Bonsai.Harp.Visualizers/TimelineGraphView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/Bonsai.Harp.Visualizers/TimelineGraphVisualizer.cs
+++ b/Bonsai.Harp.Visualizers/TimelineGraphVisualizer.cs
@@ -58,7 +58,7 @@ namespace Bonsai.Harp.Visualizers
             view.Dock = DockStyle.Fill;
             view.Graph.AutoScaleX = false;
             view.TimeSpan = controller.TimeSpan.GetValueOrDefault(TimeSpan);
-            view.CanEditTimeSpan = controller.TimeSpan.HasValue;
+            view.CanEditTimeSpan = !controller.TimeSpan.HasValue;
             GraphHelper.FormatTimeAxis(view.Graph.GraphPane.XAxis);
             GraphHelper.SetAxisLabel(view.Graph.GraphPane.XAxis, "Time");
             GraphHelper.SetAxisLabel(view.Graph.GraphPane.YAxis, "Register");

--- a/Bonsai.Harp.Visualizers/TimelineGraphVisualizer.cs
+++ b/Bonsai.Harp.Visualizers/TimelineGraphVisualizer.cs
@@ -68,11 +68,18 @@ namespace Bonsai.Harp.Visualizers
             CompositeDisposable subscriptions = new();
             view.HandleCreated += delegate
             {
-                subscriptions.Add(controller.Registers.ObserveOn(view).Subscribe(register =>
+                subscriptions.Add(controller.Registers.Subscribe(register =>
                 {
                     var label = GetRegisterInfo(register, out int address);
                     var color = GraphControl.GetColor(address);
                     var points = new BoundedPointPairList();
+                    view.BeginInvoke((Action)(() =>
+                    {
+                        var series = view.Graph.CreateSeries(label, points, color);
+                        view.Graph.GraphPane.CurveList.Add(series);
+                        view.Graph.Invalidate();
+                    }));
+
                     subscriptions.Add(register
                     .Select(message => message.GetTimestamp())
                     .Buffer(() => timerTick)
@@ -101,9 +108,6 @@ namespace Bonsai.Harp.Visualizers
                         view.Graph.XMax = currentTime;
                         view.Graph.Invalidate();
                     }));
-                    var series = view.Graph.CreateSeries(label, points, color);
-                    view.Graph.GraphPane.CurveList.Add(series);
-                    view.Graph.Invalidate();
                 }));
             };
 

--- a/Bonsai.Harp.Visualizers/TimelineGraphVisualizer.cs
+++ b/Bonsai.Harp.Visualizers/TimelineGraphVisualizer.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Windows.Forms;
+using Bonsai.Design;
+using Bonsai.Design.Visualizers;
+using Bonsai.Expressions;
+
+namespace Bonsai.Harp.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer to display a sequence of Harp messages as a synchronized rolling graph.
+    /// </summary>
+    public class TimelineGraphVisualizer : DialogTypeVisualizer
+    {
+        const int TargetInterval = 1000 / 50;
+        TimelineGraphBuilder.VisualizerController controller;
+        TimelineGraphView view;
+        Timer timer;
+
+        /// <summary>
+        /// Gets or sets the maximum time range, in seconds, displayed at any one moment in the graph.
+        /// </summary>
+        public double TimeSpan { get; set; }
+
+        static string GetRegisterInfo(IObservable<HarpMessage> register, out int address)
+        {
+            switch (register)
+            {
+                case IGroupedObservable<int, HarpMessage> addressRegister:
+                    address = addressRegister.Key;
+                    return address.ToString();
+                case IGroupedObservable<Type, HarpMessage> typedRegister:
+                    var addressField = typedRegister.Key.GetField(nameof(WhoAmI.Address), BindingFlags.Static | BindingFlags.Public);
+                    address = (int)addressField.GetValue(null);
+                    return typedRegister.Key.Name;
+                default:
+                    throw new ArgumentException("Unsupported register type.", nameof(register));
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var timelineBuilder = (TimelineGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            controller = timelineBuilder.Controller;
+
+            timer = new Timer();
+            timer.Interval = TargetInterval;
+            var timerTick = Observable.FromEventPattern<EventHandler, EventArgs>(
+                handler => timer.Tick += handler,
+                handler => timer.Tick -= handler);
+            timer.Start();
+
+            view = new TimelineGraphView();
+            view.Dock = DockStyle.Fill;
+            view.Graph.AutoScaleX = false;
+            view.TimeSpan = controller.TimeSpan.GetValueOrDefault(TimeSpan);
+            view.CanEditTimeSpan = controller.TimeSpan.HasValue;
+            GraphHelper.FormatTimeAxis(view.Graph.GraphPane.XAxis);
+            GraphHelper.SetAxisLabel(view.Graph.GraphPane.XAxis, "Time");
+            GraphHelper.SetAxisLabel(view.Graph.GraphPane.YAxis, "Register");
+
+            var currentTime = 0.0;
+            var absoluteMinTime = double.MaxValue;
+            CompositeDisposable subscriptions = new();
+            view.HandleCreated += delegate
+            {
+                subscriptions.Add(controller.Registers.ObserveOn(view).Subscribe(register =>
+                {
+                    var label = GetRegisterInfo(register, out int address);
+                    var color = GraphControl.GetColor(address);
+                    var points = new BoundedPointPairList();
+                    subscriptions.Add(register
+                    .Select(message => message.GetTimestamp())
+                    .Buffer(() => timerTick)
+                    .Subscribe(buffer =>
+                    {
+                        if (buffer.Count == 0) return;
+                        foreach (var timestamp in buffer)
+                        {
+                            absoluteMinTime = Math.Min(absoluteMinTime, timestamp);
+                            currentTime = Math.Max(currentTime, timestamp);
+                            points.Add(timestamp, address);
+                        }
+
+                        if (view.TimeSpan > 0)
+                        {
+                            var relativeMinTime = currentTime - view.TimeSpan;
+                            foreach (var series in view.Graph.GraphPane.CurveList)
+                            {
+                                ((BoundedPointPairList)series.Points).SetBounds(
+                                    relativeMinTime,
+                                    double.MaxValue);
+                            }
+                            view.Graph.XMin = Math.Max(absoluteMinTime, relativeMinTime);
+                        }
+                        else view.Graph.XMin = absoluteMinTime;
+                        view.Graph.XMax = currentTime;
+                        view.Graph.Invalidate();
+                    }));
+                    var series = view.Graph.CreateSeries(label, points, color);
+                    view.Graph.GraphPane.CurveList.Add(series);
+                    view.Graph.Invalidate();
+                }));
+            };
+
+            view.HandleDestroyed += delegate
+            {
+                subscriptions.Dispose();
+                TimeSpan = view.TimeSpan;
+            };
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            visualizerService?.AddControl(view);
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override IObservable<object> Visualize(IObservable<IObservable<object>> source, IServiceProvider provider)
+        {
+            return Observable.Empty<object>();
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            view?.Dispose();
+            timer?.Dispose();
+            view = null;
+            timer = null;
+            controller = null;
+        }
+    }
+}

--- a/Bonsai.Harp.Visualizers/ToolStripEditableLabel.cs
+++ b/Bonsai.Harp.Visualizers/ToolStripEditableLabel.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace Bonsai.Harp.Visualizers
+{
+    class ToolStripEditableLabel : IComponent
+    {
+        readonly ToolStripTextBox textBox;
+        readonly ToolStripStatusLabel valueLabel;
+        readonly Action<string> onEdit;
+        bool disposed;
+
+        public ToolStripEditableLabel(ToolStripStatusLabel statusLabel, Action<string> onLabelEdit)
+        {
+            if (statusLabel is null)
+            {
+                throw new ArgumentNullException(nameof(statusLabel));
+            }
+
+            onEdit = onLabelEdit;
+            valueLabel = statusLabel;
+            textBox = new ToolStripTextBox();
+            textBox.LostFocus += textBox_LostFocus;
+            textBox.KeyDown += textBox_KeyDown;
+            valueLabel.Click += valueLabel_Click;
+        }
+
+        public bool Enabled { get; set; } = true;
+
+        public ISite Site { get; set; }
+
+        public event EventHandler Disposed;
+
+        private void textBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Return)
+            {
+                e.SuppressKeyPress = true;
+                if (textBox.Owner is StatusStrip statusStrip)
+                {
+                    statusStrip.Select();
+                }
+            }
+        }
+
+        private void textBox_LostFocus(object sender, EventArgs e)
+        {
+            if (textBox.Text != valueLabel.Text && onEdit != null)
+            {
+                onEdit(textBox.Text);
+            }
+
+            if (textBox.Owner is StatusStrip statusStrip)
+            {
+                var labelIndex = statusStrip.Items.IndexOf(textBox);
+                statusStrip.SuspendLayout();
+                statusStrip.Items.Remove(textBox);
+                statusStrip.Items.Insert(labelIndex, valueLabel);
+                statusStrip.ResumeLayout();
+            }
+        }
+
+        private void valueLabel_Click(object sender, EventArgs e)
+        {
+            if (Enabled && valueLabel.Owner is StatusStrip statusStrip)
+            {
+                var labelIndex = statusStrip.Items.IndexOf(valueLabel);
+                statusStrip.SuspendLayout();
+                statusStrip.Items.Remove(valueLabel);
+                statusStrip.Items.Insert(labelIndex, textBox);
+                textBox.Size = valueLabel.Size;
+                textBox.Text = valueLabel.Text;
+                statusStrip.ResumeLayout();
+                textBox.Focus();
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    textBox.Dispose();
+                    Disposed?.Invoke(this, EventArgs.Empty);
+                }
+
+                disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Bonsai.Harp.sln
+++ b/Bonsai.Harp.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30225.117
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34031.279
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Harp", "Bonsai.Harp\Bonsai.Harp.csproj", "{4794A074-C5B6-4A4A-BA69-B35087E429F3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Harp.Tests", "Bonsai.Harp.Tests\Bonsai.Harp.Tests.csproj", "{7E2BF5CA-F84D-4EBD-9F52-AD4EC21562E6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Harp.Design", "Bonsai.Harp.Design\Bonsai.Harp.Design.csproj", "{D2964BE5-B758-4AC8-B5D7-29602354FBE6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Harp.Visualizers", "Bonsai.Harp.Visualizers\Bonsai.Harp.Visualizers.csproj", "{2AE41D5A-630E-4321-ACD3-CE63A3F04FAD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C147D606-D6F6-4C4D-9977-8A9B1D972C01}"
 	ProjectSection(SolutionItems) = preProject
@@ -33,6 +35,10 @@ Global
 		{D2964BE5-B758-4AC8-B5D7-29602354FBE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2964BE5-B758-4AC8-B5D7-29602354FBE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2964BE5-B758-4AC8-B5D7-29602354FBE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2AE41D5A-630E-4321-ACD3-CE63A3F04FAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2AE41D5A-630E-4321-ACD3-CE63A3F04FAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2AE41D5A-630E-4321-ACD3-CE63A3F04FAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2AE41D5A-630E-4321-ACD3-CE63A3F04FAD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds a new visualizer for synchronized Harp message streams. It takes a grouped or ungrouped stream of messages and plots every message as a point, where the X-coordinate is taken from the message timestamp along a shared time axis, and the Y-coordinate is the message register address.

The `TimeSpan` property can be optionally specified to restrict the number of plotted messages to a specific interval. In this case, the most recent messages are always taken, and messages older than the specified time span from the most recent message timestamp will be discarded.

The new `TimelineGraph` operator is introduced as a new package `Bonsai.Harp.Visualizers`.