### PR TITLE
Enable DTR flag in serial object

### DIFF
--- a/Bonsai.Harp/SerialTransport.cs
+++ b/Bonsai.Harp/SerialTransport.cs
@@ -20,6 +20,7 @@ namespace Bonsai.Harp
             serialPort = new SerialPort(portName, DefaultBaudRate, Parity.None, 8, StopBits.One);
             serialPort.ReadBufferSize = DefaultReadBufferSize;
             serialPort.Handshake = Handshake.RequestToSend;
+            serialPort.DtrEnable = true;
             RunAsync(taskCancellation.Token);
         }
 


### PR DESCRIPTION
This PR enables the DTR flag when creating the serial object to communicate with harp boards. Enabling this virtual pin allows boards to use it as a way to query the connection state of the serial connection. This is very useful as it can be exploited to drive devices to an active or inactive state.

This strategy has been tested with Atmega-based architectures, which don't seem to produce any functional changes (which makes sense given how the DTR pin in the FTDI is floating). It has also been tested with the RP2040 architecture to drive the aforementioned behavior. 

It might be worth considering adding the DTR pin behavior to the harp core in the future.