### PR TITLE
Ensure transport is closed on shutdown IO errors

### DIFF
--- a/Bonsai.Harp/Bonsai.Harp.csproj
+++ b/Bonsai.Harp/Bonsai.Harp.csproj
@@ -7,7 +7,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <VersionPrefix>3.5.1</VersionPrefix>
+    <VersionPrefix>3.5.2</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
At shutdown, the device should usually be sent into `Standby` mode before closing the serial connection. However, if this transmission fails due to IO issues (e.g. a cable has been disconnected), we should still make sure we close the connection.