### PR TITLE
Add support for setting message flags

### DIFF
--- a/Bonsai.Harp/MessageFlags.cs
+++ b/Bonsai.Harp/MessageFlags.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Bonsai.Harp
+{
+    /// <summary>
+    /// Specifies optional flags associated with a Harp message.
+    /// </summary>
+    [Flags]
+    public enum MessageFlags : byte
+    {
+        /// <summary>
+        /// Indicates that the message is an error message.
+        /// </summary>
+        Error = 0x08,
+
+        /// <summary>
+        /// Indicates that the message is a cancellation message.
+        /// </summary>
+        Cancellation = 0x10
+    }
+}


### PR DESCRIPTION
This PR adds a reference implementation enabling cancellation support, following the WIP specification in https://github.com/harp-tech/protocol/issues/15. A new `MessageFlags` enum is defined, allowing setting optional flags when copying message payloads.

For now only the copy constructors are exposed with the flags parameter, both to facilitate maintenance, and to make it clear that in the general case flags should be used only for message cancellation, or in virtual devices to implement symmetric error messages.