### PR TITLE
Disable publishing documentation for the canonical repo

### DIFF
--- a/.github/workflows/Bonsai.Harp.yml
+++ b/.github/workflows/Bonsai.Harp.yml
@@ -311,8 +311,10 @@ jobs:
       name: documentation-website
       url: ${{steps.publish.outputs.page_url}}
     # Only run if the workflow isn't dying and build-documentation was successful and either A) we're releasing or B) we have continuous deployment enabled
+    # Publishing to GitHub Pages is currently disabled for the canonical repo because Bonsai.Harp's documentation is published via https://github.com/harp-tech/harp-tech.github.io
     if: |
       !cancelled() && !failure() && needs.build-documentation.result == 'success'
+      && github.event.repository.fork
       && (github.event_name == 'release'
         || (vars.CONTINUOUS_DOCUMENTATION && github.event_name != 'pull_request')
       )


### PR DESCRIPTION
The documentation for this repo is published alongside [the main Harp website](https://github.com/harp-tech/harp-tech.github.io), so we don't need a dedicated website for it.

This PR intentionally leaves the docs building job enabled for CI purposes.

The docs deployment step is still able to be used with forks for those working on documentation.