### PR TITLE
Wait after disposing device to ensure SerialPort is released

### DIFF
--- a/src/Bonsai.Harp/Bootloader.cs
+++ b/src/Bonsai.Harp/Bootloader.cs
@@ -80,8 +80,6 @@ namespace Bonsai.Harp
                         await device.WriteResetDeviceAsync(ResetFlags.RestoreDefault);
                     }
                     else throw new HarpException("The device is in an unexpected boot mode.");
-                    await Observable.Timer(flushDelay);
-                    progress?.Report(30);
                 }
             }
             catch (Exception ex) when (ex is TimeoutException || ex is IOException)
@@ -91,6 +89,9 @@ namespace Bonsai.Harp
                     throw;
                 }
             }
+
+            await Observable.Timer(flushDelay);
+            progress?.Report(30);
 
             const int MaxAttempts = 10;
             const int DefaultBaudRate = 1000000;


### PR DESCRIPTION
As per description on #99 , this PR moves the wait after the initial device Reset using block. This prevents errors when opening the SerialPort afterwards since it gives enough time for the previous connection to be closed.