### PR TITLE
Update project dependencies and modernize tests

### DIFF
--- a/src/Bonsai.Harp.Design/Bonsai.Harp.Design.csproj
+++ b/src/Bonsai.Harp.Design/Bonsai.Harp.Design.csproj
@@ -1,17 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Title>Bonsai - Harp Design Library</Title>
     <Description>Bonsai Design Library containing visualizer and editor classes for configuring Harp devices.</Description>
     <PackageTags>$(PackageTags) Design</PackageTags>
 
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Design" Version="2.8.0" />
-    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
+    <PackageReference Include="Bonsai.Design" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Harp.Tests/AssemblyInfo.cs
+++ b/src/Bonsai.Harp.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: Parallelize]

--- a/src/Bonsai.Harp.Tests/Bonsai.Harp.Tests.csproj
+++ b/src/Bonsai.Harp.Tests/Bonsai.Harp.Tests.csproj
@@ -3,10 +3,13 @@
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Harp\Bonsai.Harp.csproj" />

--- a/src/Bonsai.Harp.Tests/TestHarpMessage.cs
+++ b/src/Bonsai.Harp.Tests/TestHarpMessage.cs
@@ -7,30 +7,30 @@ namespace Bonsai.Harp.Tests
     public class TestHarpMessage
     {
         const int DefaultAddress = 42;
-        static readonly Random Generator = new Random(23);
+        static readonly Random Generator = new(23);
 
-        double GetTimestamp()
+        static double GetTimestamp()
         {
             return Math.Round(Generator.NextDouble() * 100 + Generator.NextDouble(), 6);
         }
 
-        void AssertArrayEqual<T>(T[] expected, T[] actual) where T : struct, IEquatable<T>
+        static void AssertArrayEqual<T>(T[] expected, T[] actual) where T : struct, IEquatable<T>
         {
             Assert.IsNotNull(expected);
             Assert.IsNotNull(actual);
-            Assert.AreEqual(expected.Length, actual.Length);
+            Assert.HasCount(expected.Length, actual);
             for (int i = 0; i < expected.Length; i++)
             {
                 expected[i].Equals(actual[i]);
             }
         }
 
-        void AssertIsValid(HarpMessage message)
+        static void AssertIsValid(HarpMessage message)
         {
             Assert.IsTrue(message.IsValid);
         }
 
-        void AssertTimestamp(double expected, double actual)
+        static void AssertTimestamp(double expected, double actual)
         {
             Assert.AreEqual(expected, actual, 32e-6);
         }
@@ -498,7 +498,7 @@ namespace Bonsai.Harp.Tests
             AssertIsValid(message);
             var actualTimestamp = message.GetTimestamp();
             AssertTimestamp(timestamp, actualTimestamp);
-            Assert.AreEqual(payloadSegment.Count, message.GetPayloadArray<byte>().Length);
+            Assert.HasCount(payloadSegment.Count, message.GetPayloadArray<byte>());
             Assert.AreEqual(value, message.GetPayloadUInt16());
         }
     }

--- a/src/Bonsai.Harp.Tests/TestHarpVersion.cs
+++ b/src/Bonsai.Harp.Tests/TestHarpVersion.cs
@@ -24,7 +24,7 @@ namespace Bonsai.Harp.Tests
             Assert.IsFalse(a > b); Assert.IsTrue(b > a);
             AssertOperatorConsistent(a, b); AssertOperatorConsistent(b, a);
             Assert.IsFalse(EqualityComparer<HarpVersion>.Default.Equals(a, b));
-            Assert.IsTrue(Comparer<HarpVersion>.Default.Compare(a, b) < 0);
+            Assert.IsLessThan(0, Comparer<HarpVersion>.Default.Compare(a, b));
         }
 
         static void AssertGreaterThan(HarpVersion a, HarpVersion b)
@@ -34,7 +34,7 @@ namespace Bonsai.Harp.Tests
             Assert.IsTrue(a > b); Assert.IsFalse(b > a);
             AssertOperatorConsistent(a, b); AssertOperatorConsistent(b, a);
             Assert.IsFalse(EqualityComparer<HarpVersion>.Default.Equals(a, b));
-            Assert.IsTrue(Comparer<HarpVersion>.Default.Compare(a, b) > 0);
+            Assert.IsGreaterThan(0, Comparer<HarpVersion>.Default.Compare(a, b));
         }
 
         static void AssertOperatorConsistent(HarpVersion a, HarpVersion b)
@@ -130,24 +130,21 @@ namespace Bonsai.Harp.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
         public void InvalidParseRunawayCharacters_ThrowsException()
         {
-            HarpVersion.Parse("1.xx");
+            Assert.ThrowsExactly<ArgumentException>(() => HarpVersion.Parse("1.xx"));
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
         public void InvalidParseInvalidSeparator_ThrowsException()
         {
-            HarpVersion.Parse("1;2");
+            Assert.ThrowsExactly<ArgumentException>(() => HarpVersion.Parse("1;2"));
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
         public void InvalidParseWithFloatingMajor_ThrowsException()
         {
-            HarpVersion.Parse("x.1");
+            Assert.ThrowsExactly<ArgumentException>(() => HarpVersion.Parse("x.1"));
         }
     }
 }

--- a/src/Bonsai.Harp.Visualizers/Bonsai.Harp.Visualizers.csproj
+++ b/src/Bonsai.Harp.Visualizers/Bonsai.Harp.Visualizers.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Design.Visualizers" Version="2.8.0" />
+    <PackageReference Include="Bonsai.Design.Visualizers" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Harp/Bonsai.Harp.csproj
+++ b/src/Bonsai.Harp/Bonsai.Harp.csproj
@@ -4,12 +4,12 @@
     <Title>Bonsai - Harp Library</Title>
     <Description>Bonsai Library containing interfaces for data acquisition and control of devices implementing the Harp protocol.</Description>
 
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.8.0" />
-    <PackageReference Include="Bonsai.System" Version="2.8.0" />
+    <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Bonsai.System" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Target framework is bumped up to net472 for core compatibility. All dependencies are updated to their latest stable versions. `System.Resources.Extensions` is removed and left as a transitive dependency to keep alignment with core design package dependencies.