### PR TITLE
Implement IAsyncDisposable for AsyncDevice objects

### DIFF
--- a/src/Bonsai.Harp/AsyncDevice.cs
+++ b/src/Bonsai.Harp/AsyncDevice.cs
@@ -9,7 +9,7 @@ namespace Bonsai.Harp
     /// <summary>
     /// Represents an asynchronous API to configure and interface with Harp devices.
     /// </summary>
-    public class AsyncDevice : IDisposable
+    public class AsyncDevice : IDisposable, IAsyncDisposable
     {
         readonly bool _leaveOpen;
         readonly SerialTransport transport;
@@ -923,6 +923,15 @@ namespace Bonsai.Harp
             if (!_leaveOpen)
             {
                 transport.Close();
+            }
+            response.Dispose();
+        }
+
+        async ValueTask IAsyncDisposable.DisposeAsync()
+        {
+            if (!_leaveOpen)
+            {
+                await transport.CloseAsync();
             }
             response.Dispose();
         }

--- a/src/Bonsai.Harp/Bonsai.Harp.csproj
+++ b/src/Bonsai.Harp/Bonsai.Harp.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.9.0" />
     <PackageReference Include="Bonsai.System" Version="2.9.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Harp/Bootloader.cs
+++ b/src/Bonsai.Harp/Bootloader.cs
@@ -56,7 +56,7 @@ namespace Bonsai.Harp
             var flushDelay = TimeSpan.FromMilliseconds(FlushDelayMilliseconds);
             try
             {
-                using (var device = new AsyncDevice(portName))
+                await using (var device = new AsyncDevice(portName))
                 {
                     progress?.Report(10);
                     if (!forceUpdate)


### PR DESCRIPTION
This is an explicit implementation meant to allow using the `await using` pattern, when keeping track of disposal completion is required.