### PR TITLE
Add support for `Timestamped<HarpMessage>` overload in `Format` when `address` is null

### DIFF
--- a/src/Bonsai.Harp/Format.cs
+++ b/src/Bonsai.Harp/Format.cs
@@ -285,14 +285,14 @@ namespace Bonsai.Harp
 
         Expression GetAddressExpression(Expression expression, Expression combinator)
         {
-            return expression.Type == typeof(HarpMessage)
+            return expression.Type == typeof(HarpMessage) || expression.Type == typeof(Timestamped<HarpMessage>)
                 ? Expression.Call(combinator, nameof(GetMessageAddress), null, expression)
                 : Expression.Call(combinator, nameof(GetMessageAddress), null);
         }
 
         Expression GetMessageTypeExpression(Expression expression, Expression combinator)
         {
-            return expression.Type == typeof(HarpMessage)
+            return expression.Type == typeof(HarpMessage) || expression.Type == typeof(Timestamped<HarpMessage>)
                 ? Expression.Call(combinator, nameof(GetMessageType), null, expression)
                 : Expression.Call(combinator, nameof(GetMessageType), null);
         }
@@ -311,6 +311,11 @@ namespace Bonsai.Harp
             return address.HasValue ? address.GetValueOrDefault() : message.Address;
         }
 
+        int GetMessageAddress(Timestamped<HarpMessage> timestamped)
+        {
+            return GetMessageAddress(timestamped.Value);
+        }
+
         MessageType GetMessageType()
         {
             var messageType = MessageType;
@@ -323,6 +328,11 @@ namespace Bonsai.Harp
         {
             var messageType = MessageType;
             return messageType.HasValue ? messageType.GetValueOrDefault() : message.MessageType;
+        }
+
+        MessageType GetMessageType(Timestamped<HarpMessage> timestamped)
+        {
+            return GetMessageType(timestamped.Value);
         }
     }
 }


### PR DESCRIPTION
Closes #71 

I simply added the specific overload and routed the type via the existing `HarpMessage` code path.

I did not see any tests for the `Format` operator or builder. We should probably think about making some sort of harness for this package at some point in the future.